### PR TITLE
Updates token filter for GetNextToken / GetPreviousToken / etc to inc…

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static Func<SyntaxToken, bool> GetPredicateFunction(bool includeZeroWidth)
         {
-            return includeZeroWidth ? SyntaxToken.Any : SyntaxToken.NonZeroWidth;
+            return includeZeroWidth ? SyntaxToken.Any : SyntaxToken.NonZeroWidthOrFake;
         }
 
         private static bool Matches(Func<SyntaxToken, bool>? predicate, SyntaxToken token)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly Func<DiagnosticInfo, Diagnostic> s_createDiagnosticWithoutLocation = Diagnostic.Create;
 
         internal static readonly Func<SyntaxToken, bool> NonZeroWidth = t => t.Width > 0;
+        internal static readonly Func<SyntaxToken, bool> NonZeroWidthOrFake = t => t.Width > 0 || (t.RawKind >= 8193 && t.RawKind <= 8222); /* allow all C# punctuation tokens ... even if they are "fake" ... */
         internal static readonly Func<SyntaxToken, bool> Any = t => true;
 
         internal SyntaxToken(SyntaxNode? parent, GreenNode? token, int position, int index)


### PR DESCRIPTION
This fixes completion when typing statements / expression following a previous statement that ended without a semicomma - which is a valid syntax.

The reason for this is GetNextToken / GetPreviousToken and their like is used in many places, depending on that a previous statement ended with ";" ... but when a "fake" token is used as a ";" ... it would not be included.

This includes the fake tokens as well - making the syntax context evaluation logic checks for ";" work again.