### PR TITLE
Feature/lambda this scope

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The type containing the binding context
         /// </summary>
-        internal NamedTypeSymbol? ContainingType
+        internal virtual NamedTypeSymbol? ContainingType
         {
             get
             {
@@ -449,6 +449,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     NamedTypeSymbol namedType => namedType,
                     _ => member.ContainingType
                 };
+            }
+        }
+
+        protected virtual NamedTypeSymbol? ParentContainingType
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        protected virtual bool InLambdaWithThisScope
+        {
+            get
+            {
+                ContainingMemberOrLambda.ContainingSymbolWithThisScope(out var islabmda);
+                return islabmda;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case TypeKind.Error:
-                    LookupMembersInErrorType(result, (ErrorTypeSymbol)type, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
+                    LookupMembersInErrorType(result, (ErrorTypeSymbol)type.Self, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
                     break;
 
                 case TypeKind.Pointer:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public int ArgumentFromParameter(int param)
         {
             Debug.Assert(param >= 0);
-            if (ArgsToParamsOpt.IsDefault) return param;
+            if (ArgsToParamsOpt.IsDefault) return -1;
             for (var i = 0; i < ArgsToParamsOpt.Length; ++i)
             {
                 if (ArgsToParamsOpt[i] == param) return i;
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public int UnmatchedArgumentFromParameter(int param)
         {
             Debug.Assert(param >= 0);
-            if (UnmatchedArgsToParamsOpt.IsDefault) return param;
+            if (UnmatchedArgsToParamsOpt.IsDefault) return -1;
             for (var i = 0; i < UnmatchedArgsToParamsOpt.Length; ++i)
             {
                 if (UnmatchedArgsToParamsOpt[i] == param) return i;
@@ -72,11 +72,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.UnmatchedArgsToParamsOpt = unmatchedArgsToParamsOpt;
             this.HasSpreadParameters = false;
             this.HasUnmatchedLambdaArguments = false;
+            this.HasLambdaArgumentsWithThisScope = false;
         }
 
         public bool HasSpreadParameters { get; set; }
 
         public bool HasUnmatchedLambdaArguments { get; set; }
+
+        public bool HasLambdaArgumentsWithThisScope { get; set; }
 
         public bool IsValid
         {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -87,6 +87,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal BoundNode WithOriginalSyntax(SyntaxNode originalSyntax)
+        {
+            // we hackishly replace the syntax back to the old syntax ... but keep the binding and such ...
+            GeneratedSyntax = Syntax;
+            Syntax = originalSyntax;
+            return this;
+        }
+
         /// <summary>
         /// Determines if a bound node, or associated syntax or type has an error (not a warning) 
         /// diagnostic associated with it.

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4617,9 +4617,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var name = node.Name;
 
             // Extension methods, all scopes.
-            if (node.SearchExtensionMethods)
+            if (node.SearchExtensionMethods && receiver != null)
             {
-                Debug.Assert(receiver != null);
                 int arity;
                 LookupOptions options;
                 if (typeArguments.IsDefault)

--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return true; }
         }
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.AliasSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -473,12 +473,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #endregion
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.ArrayTypeSymbol(this, DefaultNullableAnnotation);
         }
 
-        protected sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
+        protected internal sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
         {
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.ArrayTypeSymbol(this, nullableAnnotation);

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -931,7 +931,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public abstract AssemblyMetadata GetMetadata();
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.NonSourceAssemblySymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -810,7 +810,9 @@ hasRelatedInterfaces:
             Debug.Assert(substitution != null);
 
             // The type parameters must be original definitions of type parameters from the containing symbol.
-            Debug.Assert(ReferenceEquals(typeParameter.ContainingSymbol, containingSymbol.OriginalDefinition));
+            var assertIsTrue = ReferenceEquals(typeParameter.ContainingSymbol, containingSymbol.OriginalDefinition);
+            assertIsTrue = assertIsTrue || (containingSymbol is NamedTypeSymbolWithAnnotations namedTypeWithAnnotations && ReferenceEquals(typeParameter.ContainingSymbol, containingSymbol.OriginalDefinition.OriginalDefinition));
+            Debug.Assert(assertIsTrue);
 
             if (typeArgument.Type.IsErrorType())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override bool Equals(Symbol? obj, TypeCompareKind compareKind) => obj is DiscardSymbol other && this.TypeWithAnnotations.Equals(other.TypeWithAnnotations, compareKind);
         public override int GetHashCode() => this.TypeWithAnnotations.GetHashCode();
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.DiscardSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -237,12 +237,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this;
         }
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.DynamicTypeSymbol(this, DefaultNullableAnnotation);
         }
 
-        protected sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
+        protected internal sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
         {
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.DynamicTypeSymbol(this, nullableAnnotation);

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
 
-        protected override NamedTypeSymbol ConstructCore(ImmutableArray<TypeWithAnnotations> typeArguments, bool unbound)
+        protected internal override NamedTypeSymbol ConstructCore(ImmutableArray<TypeWithAnnotations> typeArguments, bool unbound)
         {
             return new ConstructedErrorTypeSymbol(this, typeArguments);
         }
@@ -535,12 +535,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override NamedTypeSymbol? NativeIntegerUnderlyingType => null;
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.ErrorTypeSymbol(this, DefaultNullableAnnotation);
         }
 
-        protected sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
+        protected internal sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
         {
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.ErrorTypeSymbol(this, nullableAnnotation);

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        protected override int HighestPriorityUseSiteError
+        protected internal override int HighestPriorityUseSiteError
         {
             get
             {
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #endregion
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.EventSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Return error code that has highest priority while calculating use site error for this symbol. 
         /// </summary>
-        protected override int HighestPriorityUseSiteError
+        protected internal override int HighestPriorityUseSiteError
         {
             get
             {
@@ -451,7 +451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         bool IFieldSymbolInternal.IsVolatile => this.IsVolatile;
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.FieldSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -111,12 +111,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Hash.Combine(1, Signature.GetHashCode());
         }
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.FunctionPointerTypeSymbol(this, DefaultNullableAnnotation);
         }
 
-        protected override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
+        protected internal override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
         {
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.FunctionPointerTypeSymbol(this, nullableAnnotation);

--- a/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.LabelSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal virtual ErrorCode ForbiddenDiagnostic => ErrorCode.ERR_VariableUsedBeforeDeclaration;
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.LocalSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -946,7 +946,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Return error code that has highest priority while calculating use site error for this symbol.
         /// </summary>
-        protected override int HighestPriorityUseSiteError
+        protected internal override int HighestPriorityUseSiteError
         {
             get
             {
@@ -1078,7 +1078,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #endregion
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.MethodSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public abstract ModuleMetadata GetMetadata();
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.ModuleSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1062,7 +1062,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this.ConstructCore(typeArguments, unbound);
         }
 
-        protected virtual NamedTypeSymbol ConstructCore(ImmutableArray<TypeWithAnnotations> typeArguments, bool unbound)
+        protected internal virtual NamedTypeSymbol ConstructCore(ImmutableArray<TypeWithAnnotations> typeArguments, bool unbound)
         {
             return new ConstructedNamedTypeSymbol(this, typeArguments, unbound);
         }
@@ -1528,12 +1528,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract NamedTypeSymbol NativeIntegerUnderlyingType { get; }
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.NonErrorNamedTypeSymbol(this, DefaultNullableAnnotation);
         }
 
-        protected override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
+        protected internal override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
         {
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.NonErrorNamedTypeSymbol(this, nullableAnnotation);

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.NamespaceSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         internal const string ValueParameterName = "value";
 
+        private bool _isThis;
+
         internal ParameterSymbol()
         {
         }
@@ -373,7 +375,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return false;
+                return _isThis;
+            }
+            set
+            {
+                _isThis = value;
             }
         }
 
@@ -400,7 +406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract ImmutableHashSet<string> NotNullIfParameterNotNull { get; }
 
-        protected sealed override int HighestPriorityUseSiteError
+        protected internal sealed override int HighestPriorityUseSiteError
         {
             get
             {
@@ -418,7 +424,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.ParameterSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -296,12 +296,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this.PointedAtTypeWithAnnotations.GetUnificationUseSiteDiagnosticRecursive(ref result, owner, ref checkedTypes);
         }
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.PointerTypeSymbol(this, DefaultNullableAnnotation);
         }
 
-        protected override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
+        protected internal override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
         {
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.PointerTypeSymbol(this, nullableAnnotation);

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Return error code that has highest priority while calculating use site error for this symbol. 
         /// </summary>
-        protected override int HighestPriorityUseSiteError
+        protected internal override int HighestPriorityUseSiteError
         {
             get
             {
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #endregion
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.PropertySymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Hash.Combine(_locations[0].GetHashCode(), _containingSymbol.GetHashCode());
         }
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.RangeVariableSymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -48,6 +48,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_DefaultConstructorRequiredForSpreadParam, syntax.Location, parameterType.Type.Name);
                     }
 
+                    var isThis = syntax?.Modifiers.Any(SyntaxKind.ThisKeyword) == true;
+
                     var p = SourceParameterSymbol.Create(
                         context,
                         owner,
@@ -62,6 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         declarationDiagnostics);
 
                     p.IsSpread = isSpread;
+                    p.IsThis = isThis;
 
                     return p;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2672,7 +2672,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override AssemblyMetadata GetMetadata() => null;
 
-        protected override ISymbol CreateISymbol()
+        protected internal override ISymbol CreateISymbol()
         {
             return new PublicModel.SourceAssemblySymbol(this);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -37,7 +37,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal SubstitutedMethodSymbol(NamedTypeSymbol containingSymbol, MethodSymbol originalDefinition)
             : this(containingSymbol, containingSymbol.TypeSubstitution, originalDefinition, constructedFrom: null)
         {
-            Debug.Assert(containingSymbol is SubstitutedNamedTypeSymbol || containingSymbol is SubstitutedErrorTypeSymbol);
+            var assertIsTrue = containingSymbol is SubstitutedNamedTypeSymbol || containingSymbol is SubstitutedErrorTypeSymbol;
+            assertIsTrue = assertIsTrue || (containingSymbol as NamedTypeSymbolWithAnnotations).UnderlyingType is SubstitutedNamedTypeSymbol || (containingSymbol as NamedTypeSymbolWithAnnotations).UnderlyingType is SubstitutedErrorTypeSymbol;
+
+            Debug.Assert(assertIsTrue);
             Debug.Assert(TypeSymbol.Equals(originalDefinition.ContainingType, containingSymbol.OriginalDefinition, TypeCompareKind.ConsiderEverything2));
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -888,7 +888,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Return error code that has highest priority while calculating use site error for this symbol. 
         /// Supposed to be ErrorCode, but it causes inconsistent accessibility error.
         /// </summary>
-        protected virtual int HighestPriorityUseSiteError
+        protected internal virtual int HighestPriorityUseSiteError
         {
             get
             {
@@ -1560,7 +1560,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ToString();
         }
 
-        protected abstract ISymbol CreateISymbol();
+        protected internal abstract ISymbol CreateISymbol();
 
         internal ISymbol ISymbol
         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
 
-        protected override ImmutableArray<NamedTypeSymbol> GetAllInterfaces()
+        protected internal override ImmutableArray<NamedTypeSymbol> GetAllInterfaces()
         {
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
@@ -676,12 +676,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this;
         }
 
-        protected sealed override ISymbol CreateISymbol()
+        protected internal sealed override ISymbol CreateISymbol()
         {
             return new PublicModel.TypeParameterSymbol(this, DefaultNullableAnnotation);
         }
 
-        protected sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
+        protected internal sealed override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation)
         {
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.TypeParameterSymbol(this, nullableAnnotation);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
@@ -6,8 +6,19 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
+    internal enum TypeAnnotationKind
+    {
+        ThisParamType
+    }
+
     internal partial class TypeSymbol
     {
+        internal TypeAnnotationKind? AnnotationTypeKind { get; set; }
+
+        internal TypeSymbol AnnotationType { get; set; }
+
+        internal virtual TypeSymbol Self => this;
+
         /// <summary>
         /// Represents the method by which this type implements a given interface type
         /// and/or the corresponding diagnostics.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        protected virtual ImmutableArray<NamedTypeSymbol> GetAllInterfaces()
+        protected internal virtual ImmutableArray<NamedTypeSymbol> GetAllInterfaces()
         {
             var info = this.GetInterfaceInfo();
             if (info == s_noInterfaces)
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// TypeSymbol.Interfaces as the source of edge data, which has had cycles and infinitely
         /// long dependency cycles removed. Consequently, it is possible (and we do) use the
         /// simplest version of Tarjan's topological sorting algorithm.
-        protected virtual ImmutableArray<NamedTypeSymbol> MakeAllInterfaces()
+        protected internal virtual ImmutableArray<NamedTypeSymbol> MakeAllInterfaces()
         {
             var result = ArrayBuilder<NamedTypeSymbol>.GetInstance();
             var visited = new HashSet<NamedTypeSymbol>(SymbolEqualityComparer.ConsiderEverything);
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Return error code that has highest priority while calculating use site error for this symbol. 
         /// </summary>
-        protected override int HighestPriorityUseSiteError
+        protected internal override int HighestPriorityUseSiteError
         {
             get
             {
@@ -2241,7 +2241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal CodeAnalysis.NullableAnnotation DefaultNullableAnnotation => NullableAnnotationExtensions.ToPublicAnnotation(this, NullableAnnotation.Oblivious);
 
-        protected abstract ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation);
+        protected internal abstract ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation);
 
         TypeKind ITypeSymbolInternal.TypeKind => this.TypeKind;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/NamedTypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/NamedTypeSymbolWithAnnotations.cs
@@ -1,0 +1,316 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal class NamedTypeSymbolWithAnnotations : NamedTypeSymbol
+    {
+        /// <summary>
+        /// The underlying NamedTypeSymbol.
+        /// </summary>
+        protected readonly NamedTypeSymbol _underlyingType;
+
+        public NamedTypeSymbolWithAnnotations(NamedTypeSymbol underlyingType, TypeSymbol annotationType, TypeAnnotationKind annotationTypeKind)
+            : base(underlyingType.TupleData)
+        {
+            _underlyingType = underlyingType;
+
+            AnnotationType = annotationType;
+            AnnotationTypeKind = annotationTypeKind;
+        }
+
+        public NamedTypeSymbol UnderlyingType => _underlyingType;
+
+        internal override TypeSymbol Self => _underlyingType;
+
+        #region Wrapped
+
+        public override bool IsImplicitlyDeclared => _underlyingType.IsImplicitlyDeclared;
+
+        public override int Arity => _underlyingType.Arity;
+
+        public override bool MightContainExtensionMethods => _underlyingType.MightContainExtensionMethods;
+
+        public override string Name => _underlyingType.Name;
+
+        public override string MetadataName => _underlyingType.MetadataName;
+
+        internal override bool HasSpecialName => _underlyingType.HasSpecialName;
+
+        internal override bool MangleName => _underlyingType.MangleName;
+
+        public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
+            => _underlyingType.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
+
+        public override Accessibility DeclaredAccessibility => _underlyingType.DeclaredAccessibility;
+
+        public override TypeKind TypeKind => _underlyingType.TypeKind;
+
+        internal override bool IsInterface => _underlyingType.IsInterface;
+
+        public override ImmutableArray<Location> Locations => _underlyingType.Locations;
+
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _underlyingType.DeclaringSyntaxReferences;
+
+        public override bool IsStatic => _underlyingType.IsStatic;
+
+        public override bool IsAbstract => _underlyingType.IsAbstract;
+
+        internal override bool IsMetadataAbstract => _underlyingType.IsMetadataAbstract;
+
+        public override bool IsSealed => _underlyingType.IsSealed;
+
+        internal override bool IsMetadataSealed => _underlyingType.IsMetadataSealed;
+
+        internal override bool HasCodeAnalysisEmbeddedAttribute => _underlyingType.HasCodeAnalysisEmbeddedAttribute;
+
+        internal override ObsoleteAttributeData ObsoleteAttributeData => _underlyingType.ObsoleteAttributeData;
+
+        internal override bool ShouldAddWinRTMembers => _underlyingType.ShouldAddWinRTMembers;
+
+        internal override bool IsWindowsRuntimeImport => _underlyingType.IsWindowsRuntimeImport;
+
+        internal override TypeLayout Layout => _underlyingType.Layout;
+
+        internal override CharSet MarshallingCharSet => _underlyingType.MarshallingCharSet;
+
+        public override bool IsSerializable => _underlyingType.IsSerializable;
+
+        public override bool IsRefLikeType => _underlyingType.IsRefLikeType;
+
+        public override bool IsReadOnly => _underlyingType.IsReadOnly;
+
+        internal override bool HasDeclarativeSecurity => _underlyingType.HasDeclarativeSecurity;
+
+        internal override IEnumerable<Microsoft.Cci.SecurityAttribute> GetSecurityInformation()
+            => _underlyingType.GetSecurityInformation();
+
+        internal override ImmutableArray<string> GetAppliedConditionalSymbols()
+            => _underlyingType.GetAppliedConditionalSymbols();
+
+        internal override AttributeUsageInfo GetAttributeUsageInfo()
+            => _underlyingType.GetAttributeUsageInfo();
+
+        internal override bool GetGuidString(out string guidString)
+            => _underlyingType.GetGuidString(out guidString);
+        #endregion
+
+        #region Abstract impl
+
+        public override NamedTypeSymbol OriginalDefinition => _underlyingType.OriginalDefinition;
+
+        internal override TypeMap TypeSubstitution => _underlyingType.TypeSubstitution;
+
+        public override ImmutableArray<TypeParameterSymbol> TypeParameters => _underlyingType.TypeParameters;
+
+        public override NamedTypeSymbol ConstructedFrom => _underlyingType.ConstructedFrom;
+
+        public override IEnumerable<string> MemberNames => _underlyingType.MemberNames;
+
+        public override bool AreLocalsZeroed => _underlyingType.AreLocalsZeroed;
+
+        public override Symbol ContainingSymbol => _underlyingType.ContainingSymbol;
+
+        internal override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotationsNoUseSiteDiagnostics => _underlyingType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+
+        internal override bool IsComImport => _underlyingType.IsComImport;
+
+        internal override NamedTypeSymbol NativeIntegerUnderlyingType => _underlyingType.NativeIntegerUnderlyingType;
+
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => _underlyingType.BaseTypeNoUseSiteDiagnostics;
+
+        public override ImmutableArray<Symbol> GetMembers() => _underlyingType.GetMembers();
+
+        public override ImmutableArray<Symbol> GetMembers(string name) => _underlyingType.GetMembers(name);
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => _underlyingType.GetTypeMembers();
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name) => _underlyingType.GetTypeMembers(name);
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity) => _underlyingType.GetTypeMembers(name, arity);
+
+        protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData) => new NamedTypeSymbolWithAnnotations(_underlyingType, AnnotationType, AnnotationTypeKind.Value);
+
+        internal override NamedTypeSymbol AsNativeInteger() => _underlyingType.AsNativeInteger();
+
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved) => _underlyingType.GetDeclaredBaseType(basesBeingResolved);
+
+        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<TypeSymbol> basesBeingResolved) => _underlyingType.GetDeclaredInterfaces(basesBeingResolved);
+
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers() => _underlyingType.GetEarlyAttributeDecodingMembers();
+
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name) => _underlyingType.GetEarlyAttributeDecodingMembers(name);
+
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => _underlyingType.GetFieldsToEmit();
+
+        internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => _underlyingType.GetInterfacesToEmit();
+
+        internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved = null) => _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved);
+        #endregion
+
+        #region Additional overrides
+        public override void Accept(CSharpSymbolVisitor visitor) => _underlyingType.Accept(visitor);
+
+        internal override TResult Accept<TArgument, TResult>(CSharpSymbolVisitor<TArgument, TResult> visitor, TArgument argument) => _underlyingType.Accept(visitor, argument);
+
+        public override TResult Accept<TResult>(CSharpSymbolVisitor<TResult> visitor) => _underlyingType.Accept(visitor);
+
+        internal override void AddDeclarationDiagnostics(DiagnosticBag diagnostics) => _underlyingType.AddDeclarationDiagnostics(diagnostics);
+
+        internal override void AddNullableTransforms(ArrayBuilder<byte> transforms) => _underlyingType.AddNullableTransforms(transforms);
+
+        internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes) => _underlyingType.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+
+        internal override void AfterAddingTypeMembersChecks(ConversionsBase conversions, DiagnosticBag diagnostics) => _underlyingType.AfterAddingTypeMembersChecks(conversions, diagnostics);
+
+        internal override bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result) => _underlyingType.ApplyNullableTransforms(defaultTransformFlag, transforms, ref position, out result);
+
+        internal override NamedTypeSymbol AsMember(NamedTypeSymbol newOwner) => _underlyingType.AsMember(newOwner);
+
+        internal override NamedTypeSymbol ComImportCoClass => _underlyingType.ComImportCoClass;
+
+        protected internal override NamedTypeSymbol ConstructCore(ImmutableArray<TypeWithAnnotations> typeArguments, bool unbound) => _underlyingType.ConstructCore(typeArguments, unbound);
+
+        public override AssemblySymbol ContainingAssembly => _underlyingType.ContainingAssembly;
+
+        internal override ModuleSymbol ContainingModule => _underlyingType.ContainingModule;
+
+        public override NamespaceSymbol ContainingNamespace => _underlyingType.ContainingNamespace;
+
+        public override NamedTypeSymbol ContainingType => _underlyingType.ContainingType;
+
+        protected internal override ISymbol CreateISymbol() => _underlyingType.CreateISymbol();
+
+        protected internal override ITypeSymbol CreateITypeSymbol(CodeAnalysis.NullableAnnotation nullableAnnotation) => _underlyingType.CreateITypeSymbol(nullableAnnotation);
+
+        internal override CSharpCompilation DeclaringCompilation => _underlyingType.DeclaringCompilation;
+
+        internal override void DecodeWellKnownAttribute(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments) => _underlyingType.DecodeWellKnownAttribute(ref arguments);
+
+        internal override CSharpAttributeData EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments)
+            => _underlyingType.EarlyDecodeWellKnownAttribute(ref arguments);
+
+        internal override void EarlyDecodeWellKnownAttributeType(NamedTypeSymbol attributeType, AttributeSyntax attributeSyntax) => _underlyingType.EarlyDecodeWellKnownAttributeType(attributeType, attributeSyntax);
+
+        public override NamedTypeSymbol EnumUnderlyingType => _underlyingType.EnumUnderlyingType;
+
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null)
+        {
+            if (t2 is NamedTypeSymbolWithAnnotations other)
+            {
+                return _underlyingType.Equals(other._underlyingType, comparison, isValueTypeOverrideOpt);
+            }
+
+            return _underlyingType.Equals(t2, comparison, isValueTypeOverrideOpt);
+        }
+
+        internal override FieldSymbol FixedElementField => _underlyingType.FixedElementField;
+
+        internal override void ForceComplete(SourceLocation locationOpt, CancellationToken cancellationToken)
+            => _underlyingType.ForceComplete(locationOpt, cancellationToken);
+
+        protected internal override ImmutableArray<NamedTypeSymbol> GetAllInterfaces() => _underlyingType.GetAllInterfaces();
+
+        public override ImmutableArray<CSharpAttributeData> GetAttributes() => _underlyingType.GetAttributes();
+
+        internal override AttributeTargets GetAttributeTarget() => _underlyingType.GetAttributeTarget();
+
+        internal override IEnumerable<CSharpAttributeData> GetCustomAttributesToEmit(PEModuleBuilder moduleBuilder) => _underlyingType.GetCustomAttributesToEmit(moduleBuilder);
+
+        internal override string GetDebuggerDisplay() => _underlyingType.GetDebuggerDisplay();
+
+        public override string GetDocumentationCommentId() => _underlyingType.GetDocumentationCommentId();
+
+        internal override IEnumerable<EventSymbol> GetEventsToEmit() => _underlyingType.GetEventsToEmit();
+
+        public override int GetHashCode() => _underlyingType.GetHashCode();
+
+        internal override IEnumerable<Symbol> GetInstanceFieldsAndEvents() => _underlyingType.GetInstanceFieldsAndEvents();
+
+        internal override LexicalSortKey GetLexicalSortKey() => _underlyingType.GetLexicalSortKey();
+
+        internal override byte? GetLocalNullableContextValue() => _underlyingType.GetLocalNullableContextValue();
+
+        internal override ManagedKind GetManagedKind(ref HashSet<DiagnosticInfo> useSiteDiagnostics) => _underlyingType.GetManagedKind(ref useSiteDiagnostics);
+
+        internal override ImmutableArray<Symbol> GetMembersUnordered() => _underlyingType.GetMembersUnordered();
+
+        internal override IEnumerable<MethodSymbol> GetMethodsToEmit() => _underlyingType.GetMethodsToEmit();
+
+        internal override byte? GetNullableContextValue() => _underlyingType.GetNullableContextValue();
+
+        internal override IEnumerable<PropertySymbol> GetPropertiesToEmit() => _underlyingType.GetPropertiesToEmit();
+
+        internal override ImmutableArray<Symbol> GetSimpleNonTypeMembers(string name) => _underlyingType.GetSimpleNonTypeMembers(name);
+
+        internal override ImmutableArray<NamedTypeSymbol> GetTypeMembersUnordered() => _underlyingType.GetTypeMembersUnordered();
+
+        internal override bool GetUnificationUseSiteDiagnosticRecursive(ref DiagnosticInfo result, Symbol owner, ref HashSet<TypeSymbol> checkedTypes)
+            => _underlyingType.GetUnificationUseSiteDiagnosticRecursive(ref result, owner, ref checkedTypes);
+
+        internal override DiagnosticInfo GetUseSiteDiagnostic() => _underlyingType.GetUseSiteDiagnostic();
+
+        internal override bool HasComplete(CompletionPart part) => _underlyingType.HasComplete(part);
+
+        protected internal override int HighestPriorityUseSiteError => _underlyingType.HighestPriorityUseSiteError;
+
+        public override bool IsAnonymousType => _underlyingType.IsAnonymousType;
+
+        internal override bool IsDefinedInSourceTree(SyntaxTree tree, TextSpan? definedWithinSpan, CancellationToken cancellationToken = default)
+            => _underlyingType.IsDefinedInSourceTree(tree, definedWithinSpan, cancellationToken);
+
+        internal override bool IsDirectlyExcludedFromCodeCoverage => _underlyingType.IsDirectlyExcludedFromCodeCoverage;
+
+        internal override bool IsExplicitDefinitionOfNoPiaLocalType => _underlyingType.IsExplicitDefinitionOfNoPiaLocalType;
+
+        public override bool IsImplicitClass => _underlyingType.IsImplicitClass;
+
+        internal override bool IsNativeIntegerType => _underlyingType.IsNativeIntegerType;
+
+        public override bool IsReferenceType => _underlyingType.IsReferenceType;
+
+        public override bool IsScriptClass => _underlyingType.IsScriptClass;
+
+        public override bool IsUnboundGenericType => _underlyingType.IsUnboundGenericType;
+
+        public override bool IsValueType => _underlyingType.IsValueType;
+
+        public override SymbolKind Kind => _underlyingType.Kind;
+
+        internal override bool KnownCircularStruct => _underlyingType.KnownCircularStruct;
+
+        internal override NamedTypeSymbol LookupMetadataType(ref MetadataTypeName emittedTypeName) => _underlyingType.LookupMetadataType(ref emittedTypeName);
+
+        protected internal override ImmutableArray<NamedTypeSymbol> MakeAllInterfaces() => _underlyingType.MakeAllInterfaces();
+
+        internal override int? MemberIndexOpt => _underlyingType.MemberIndexOpt;
+
+        internal override TypeSymbol MergeEquivalentTypes(TypeSymbol other, VarianceKind variance) => _underlyingType.MergeEquivalentTypes(other, variance);
+
+        internal override void PostDecodeWellKnownAttributes(ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes, DiagnosticBag diagnostics, AttributeLocation symbolPart, WellKnownAttributeData decodedData)
+            => _underlyingType.PostDecodeWellKnownAttributes(boundAttributes, allAttributeSyntaxNodes, diagnostics, symbolPart, decodedData);
+
+        internal override void PostEarlyDecodeWellKnownAttributeTypes() => _underlyingType.PostEarlyDecodeWellKnownAttributeTypes();
+
+        internal override bool RequiresCompletion => _underlyingType.RequiresCompletion;
+
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform) => _underlyingType.SetNullabilityForReferenceTypes(transform);
+
+        public override SpecialType SpecialType => _underlyingType.SpecialType;
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -25,11 +26,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         protected readonly NamedTypeSymbol _underlyingType;
 
-        public WrappedNamedTypeSymbol(NamedTypeSymbol underlyingType, TupleExtraData tupleData)
+        public WrappedNamedTypeSymbol(NamedTypeSymbol underlyingType, TupleExtraData tupleData, TypeSymbol annotationType = null, TypeAnnotationKind? annotationTypeKind = null)
             : base(tupleData)
         {
             Debug.Assert((object)underlyingType != null);
             _underlyingType = underlyingType;
+
+            AnnotationType = annotationType;
+            AnnotationTypeKind = annotationTypeKind;
         }
 
         public NamedTypeSymbol UnderlyingNamedType

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -1554,6 +1554,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return IdentifierName(Identifier(name));
         }
 
+        public static IdentifierNameSyntax IdentifierName(string name, SyntaxNode parent, int position)
+        {
+            return IdentifierName(Identifier(name), parent, position);
+        }
+
+        public static IdentifierNameSyntax IdentifierName(SyntaxToken identifier, SyntaxNode parent, int position)
+        {
+            switch (identifier.Kind())
+            {
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.GlobalKeyword: break;
+                default: throw new ArgumentException(nameof(identifier));
+            }
+            return (IdentifierNameSyntax)Syntax.InternalSyntax.SyntaxFactory.IdentifierName((Syntax.InternalSyntax.SyntaxToken)identifier.Node!).CreateRed(parent, position);
+        }
+
         // direct access to parsing for common grammar areas
 
         /// <summary>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -130,7 +130,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         filterText: escapedName));
                 }
 
-                var allParameterNames = parameterLists.SelectMany(pl => pl).Select(p => p.Name).ToDictionary(n => n);
+                var allParameterNames = new Dictionary<string, string>();
+                foreach (var name in parameterLists.SelectMany(pl => pl).Select(p => p.Name))
+                    allParameterNames[name] = name;
 
                 // add spread parameter symbols
                 foreach (var parameter in unspecifiedParameters)

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -244,7 +244,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
                 }
             }
 
-            var symbols = !_context.IsNameOfContext && _context.LeftToken.Parent.IsInStaticContext()
+            var isInStaticContext = _context.LeftToken.Parent.IsInStaticContext();
+            if (isInStaticContext)
+            {
+                // could possibly also be a lambda with "this parameter" scope
+                var enclosingSymbol = _context.SemanticModel.GetEnclosingSymbol(_context.Position);
+                if (enclosingSymbol is IMethodSymbol method)
+                {
+                    if (method.Parameters.FirstOrDefault()?.IsThis == true)
+                        isInStaticContext = false;
+                }
+            }
+            var symbols = !_context.IsNameOfContext && isInStaticContext
                 ? _context.SemanticModel.LookupStaticMembers(_context.LeftToken.SpanStart)
                 : _context.SemanticModel.LookupSymbols(_context.LeftToken.SpanStart);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             // color color: if you bind "A" and you get a symbol and the type of that symbol is
             // Q; and if you bind "A" *again* as a type and you get type Q, then both A.static
             // and A.instance are permitted
-            if (expression is IdentifierNameSyntax)
+            if (expression is IdentifierNameSyntax || expression is ThisExpressionSyntax)
             {
                 var instanceSymbol = semanticModel.GetSymbolInfo(expression, cancellationToken).GetAnySymbol();
 
@@ -596,7 +596,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     var instanceType = instanceSymbol.GetSymbolType();
                     if (instanceType != null)
                     {
-                        var speculativeSymbolInfo = semanticModel.GetSpeculativeSymbolInfo(expression.SpanStart, expression, SpeculativeBindingOption.BindAsTypeOrNamespace);
+                        var bindingOption = SpeculativeBindingOption.BindAsTypeOrNamespace;
+                        if (expression is ThisExpressionSyntax)
+                            bindingOption = SpeculativeBindingOption.BindAsExpression;
+
+                        var speculativeSymbolInfo = semanticModel.GetSpeculativeSymbolInfo(expression.SpanStart, expression, bindingOption);
                         if (speculativeSymbolInfo.CandidateReason != CandidateReason.NotATypeOrNamespace)
                         {
                             var staticType = speculativeSymbolInfo.GetAnySymbol().GetSymbolType();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 : token;
         }
 
-        private static bool IsWord(SyntaxToken token)
+        public static bool IsWord(this SyntaxToken token)
             => CSharpSyntaxFacts.Instance.IsWord(token);
 
         public static SyntaxToken GetNextNonZeroWidthTokenOrEndOfFile(this SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 : false;
 
             var isStatementContext = !isPreProcessorDirectiveContext
-                ? targetToken.IsBeginningOfStatementContext()
+                ? targetToken.IsBeginningOfStatementContext() || (leftToken.IsWord() && leftToken.IsBeginningOfStatementContext())
                 : false;
 
             var isGlobalStatementContext = !isPreProcessorDirectiveContext

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -187,6 +187,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     }
 
                     return false;
+
+                case SyntaxKind.IdentifierToken:
+                    {
+                        if (token.Parent?.IsKind(SyntaxKind.IdentifierName) == true &&
+                            token.Parent.Parent.IsKind(SyntaxKind.ExpressionStatement))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }
             }
 
             return false;


### PR DESCRIPTION
Adds new concept of "this scoped" lambdas - basically lambda functions with "this receiver" that can be declared - similar to how extension methods work - this enables writing "fluent syntax interfaces".

Enables syntax like:

```
// declaring a function with "this scoped" lambda
class Panel {
  public value string
}
panel(builderAction fn(this Panel)) {
  p := new Panel()
  builderAction(p) // invoke the lambda with "p" receiver - will become the "this scope" in the lambda
}

// can be used like:
panel {
  // "this" is now the "Panel" type ... hence we can use "this.value" ... which is a field part of the Panel
  this.value = "testing fluent builder"
  // we can use this without explicit receiver
  value = "another test without explicit this receiver"
  // we can call extension methods and "everything is as usual"
  DoSomethingWithPanelExtensionMethod()
}

```