### PR TITLE
Feature/interface object instantiation

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5463,7 +5463,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression result = null;
             bool hasErrors = type.IsErrorType();
-            if (type.IsAbstract)
+            if (type.IsAbstract && !type.IsInterface)
             {
                 // Report error for new of abstract type.
                 diagnostics.Add(ErrorCode.ERR_NoNewAbstract, node.Location, type);
@@ -5583,7 +5583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     hasError);
 
                 // CONSIDER: Add ResultKind field to BoundObjectCreationExpression to avoid wrapping result with BoundBadExpression.
-                if (type.IsAbstract)
+                if (type.IsAbstract && !type.IsInterface)
                 {
                     result = BadExpression(node, LookupResultKind.NotCreatable, result);
                 }
@@ -5593,7 +5593,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             LookupResultKind resultKind;
 
-            if (type.IsAbstract)
+            if (type.IsAbstract && !type.IsInterface)
             {
                 resultKind = LookupResultKind.NotCreatable;
             }
@@ -5665,9 +5665,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            var boundExpr = BindClassCreationExpression(node, type.Name, typeNode, type, analyzedArguments, diagnostics, initializerOpt, type, wasTargetTyped);
+            return boundExpr;
+
             // interfaces can't be instantiated in C#
-            diagnostics.Add(ErrorCode.ERR_NoNewAbstract, node.Location, type);
-            return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, initializerOpt, typeNode, diagnostics);
+            /*diagnostics.Add(ErrorCode.ERR_NoNewAbstract, node.Location, type);
+            return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, initializerOpt, typeNode, diagnostics);*/
         }
 
         private BoundExpression BindComImportCoClassCreationExpression(SyntaxNode node, NamedTypeSymbol interfaceType, NamedTypeSymbol coClassType, DiagnosticBag diagnostics, SyntaxNode typeNode, AnalyzedArguments analyzedArguments, InitializerExpressionSyntax initializerOpt, bool wasTargetTyped)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -730,6 +730,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (returnType.Type?.Name?.StartsWith("Task") != true)
             {
+                var originReturnType = returnType;
+
                 if (returnType.Type is null)
                 {
                     // just return a Task
@@ -760,6 +762,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         returnType = TypeWithAnnotations.Create(returnTaskTypeT);
                     }
                 }
+
+                return returnType.WithAnnotationType(originReturnType.Type, TypeAnnotationKind.OriginalType);
             }
 
             return returnType;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -93,6 +93,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private readonly AnonymousTypeManager _anonymousTypeManager;
 
+        private readonly GeneratedTypesManager _generatedTypesManager;
+
         private NamespaceSymbol? _lazyGlobalNamespace;
 
         internal readonly BuiltInOperators builtInOperators;
@@ -171,6 +173,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 return _anonymousTypeManager;
+            }
+        }
+
+        internal GeneratedTypesManager GeneratedTypesManager
+        {
+            get
+            {
+                return _generatedTypesManager;
             }
         }
 
@@ -412,6 +422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _previousSubmissionImports = new Lazy<Imports>(ExpandPreviousSubmissionImports);
             _globalNamespaceAlias = new Lazy<AliasSymbol>(CreateGlobalNamespaceAlias);
             _anonymousTypeManager = new AnonymousTypeManager(this);
+            _generatedTypesManager = new GeneratedTypesManager(this);
             this.LanguageVersion = CommonLanguageVersion(syntaxAndDeclarations.ExternalSyntaxTrees);
 
             if (isSubmission)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -164,6 +164,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var embeddedTypes = moduleBeingBuiltOpt.GetEmbeddedTypes(diagnostics);
                 methodCompiler.CompileSynthesizedMethods(embeddedTypes, diagnostics);
 
+                // Compile the generated types if any
+                compilation.GeneratedTypesManager.CompileGeneratedTypes(methodCompiler, moduleBeingBuiltOpt, diagnostics);
+                methodCompiler.WaitForWorkers();
+
                 // By this time we have processed all types reachable from module's global namespace
                 compilation.AnonymousTypeManager.AssignTemplatesNamesAndCompile(methodCompiler, moduleBeingBuiltOpt, diagnostics);
                 methodCompiler.WaitForWorkers();

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -406,6 +406,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return Compilation.AnonymousTypeManager.GetAllCreatedTemplates();
         }
 
+        public override IEnumerable<Cci.INamespaceTypeDefinition> GetGeneratedTypeDefinitions(EmitContext context)
+        {
+            if (context.MetadataOnly)
+            {
+                return SpecializedCollections.EmptyEnumerable<Cci.INamespaceTypeDefinition>();
+            }
+
+            return Compilation.GeneratedTypesManager.GetGeneratedTypes();
+        }
+
         public override IEnumerable<Cci.INamespaceTypeDefinition> GetTopLevelSourceTypeDefinitions(EmitContext context)
         {
             var namespacesToProcess = new Stack<NamespaceSymbol>();

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundStatementList(Syntax, ImmutableArray.Create(first, second)) { WasCompilerGenerated = true };
         }
 
-        public BoundReturnStatement Return(BoundExpression? expression = null)
+        public BoundReturnStatement Return(BoundExpression? expression = null, TypeSymbol? forceType = null)
         {
             Debug.Assert(CurrentFunction is { });
 
@@ -484,7 +484,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // If necessary, add a conversion on the return expression.
                 HashSet<DiagnosticInfo>? useSiteDiagnostics = null;
-                var conversion = Compilation.Conversions.ClassifyConversionFromType(expression.Type, CurrentFunction.ReturnType, ref useSiteDiagnostics);
+                var conversionType = forceType ?? CurrentFunction.ReturnType;
+                var conversion = Compilation.Conversions.ClassifyConversionFromType(expression.Type, conversionType, ref useSiteDiagnostics);
                 Debug.Assert(useSiteDiagnostics.IsNullOrEmpty());
                 Debug.Assert(conversion.Kind != ConversionKind.NoConversion);
                 if (conversion.Kind != ConversionKind.Identity)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4043,7 +4043,7 @@ parse_member_name:;
             // it can append skipped trivia to the last element, regardless of whether that element is a node or a token.
             GreenNode trailingTrivia;
             var action = this.SkipBadListTokensWithExpectedKindHelper(list.UnderlyingBuilder, isNotExpectedFunction, abortFunction, expected, out trailingTrivia);
-            if (trailingTrivia != null)
+            if (trailingTrivia != null && startToken != null)
             {
                 startToken = AddTrailingSkippedSyntax(startToken, trailingTrivia);
             }
@@ -4061,7 +4061,7 @@ parse_member_name:;
         {
             GreenNode trailingTrivia;
             var action = this.SkipBadListTokensWithErrorCodeHelper(list, isNotExpectedFunction, abortFunction, error, out trailingTrivia);
-            if (trailingTrivia != null)
+            if (trailingTrivia != null && startToken != null)
             {
                 startToken = AddTrailingSkippedSyntax(startToken, trailingTrivia);
             }
@@ -14506,6 +14506,38 @@ tryAgain:
 
 #nullable restore
 
+        private InitializerExpressionSyntax TryParseObjectOrCollectionInitializer(out ResetPoint resetPoint, out bool hasMissingTokens, out bool hasErrorDiagnostics)
+        {
+            hasMissingTokens = false;
+            hasErrorDiagnostics = false;
+            resetPoint = this.GetResetPoint();
+            InitializerExpressionSyntax initializer = null;
+            try
+            {
+                initializer = ParseObjectOrCollectionInitializer();
+            }
+            catch (Exception ex)
+            {
+                initializer = null;
+            }
+            finally
+            {
+                if (initializer != null)
+                {
+                    if (initializer.ContainsDiagnostics && initializer.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+                        hasErrorDiagnostics = true;
+
+                    // check if we have any missing tokens or error diagnostics?
+                    // (lambda.ContainsDiagnostics && lambda.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+                    var missingToken = initializer.GetFirstToken(t => t.IsMissing);
+                    if (missingToken != null)
+                        hasMissingTokens = true;
+                }
+            }
+
+            return initializer;
+        }
+
         private InitializerExpressionSyntax ParseObjectOrCollectionInitializer()
         {
             var openBrace = this.EatToken(SyntaxKind.OpenBraceToken);
@@ -14628,7 +14660,41 @@ tryAgain:
             ExpressionSyntax expression;
             if (this.CurrentToken.Kind == SyntaxKind.OpenBraceToken)
             {
-                expression = this.ParseObjectOrCollectionInitializer();
+                // try parsing object initializer first
+                expression = this.TryParseObjectOrCollectionInitializer(out var beforeInitializerResetPoint, out var initializerHasMissingTokens, out var initializerHasErrors);
+
+                // if successfully parsed initilizer, then let's accept that - even though there may be ambiguity with {...} lambda expresion... we simply have to live with it...
+                if (expression != null && !initializerHasMissingTokens && !initializerHasErrors)
+                {
+                    this.Release(ref beforeInitializerResetPoint);
+                }
+                // this could possibly be a lambda expression or another initializer expression
+                else if (AllowLambdaExpression)
+                {
+                    // reset so that we can attempt parsing the lambda
+                    this.Reset(ref beforeInitializerResetPoint);
+
+                    var lambda = TryParseLambdaExpression(out var beforeLambdaResetPoint, out var lambdaHasMissingTokens, out var lambdaHasErrors);
+
+                    if (lambda != null && !lambdaHasMissingTokens && !lambdaHasErrors)
+                    {
+                        this.Release(ref beforeLambdaResetPoint);
+                        this.Release(ref beforeInitializerResetPoint);
+                        expression = lambda;
+                    }
+                    else
+                    {
+                        // reset to the before lambda and accept the initializer "as is"
+                        this.Reset(ref beforeLambdaResetPoint);
+                        this.Release(ref beforeLambdaResetPoint);
+                        this.Release(ref beforeInitializerResetPoint);
+                    }
+                }
+                else
+                {
+                    // releset the reset point ... we will accept the expresion "as is"
+                    this.Release(ref beforeInitializerResetPoint);
+                }
             }
             else
             {
@@ -14998,6 +15064,38 @@ tryAgain:
             {
                 _pool.Free(newModifiers);
             }
+        }
+
+        private LambdaExpressionSyntax TryParseLambdaExpression(out ResetPoint resetPoint, out bool hasMissingTokens, out bool hasErrorDiagnostics)
+        {
+            hasMissingTokens = false;
+            hasErrorDiagnostics = false;
+            resetPoint = this.GetResetPoint();
+            LambdaExpressionSyntax lambda = null;
+            try
+            {
+                lambda = ParseLambdaExpression();
+            }
+            catch (Exception ex)
+            {
+                lambda = null;
+            }
+            finally
+            {
+                if (lambda != null)
+                {
+                    if (lambda.ContainsDiagnostics && lambda.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+                        hasErrorDiagnostics = true;
+
+                    // check if we have any missing tokens or error diagnostics?
+                    // (lambda.ContainsDiagnostics && lambda.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+                    var missingToken = lambda.GetFirstToken(t => t.IsMissing);
+                    if (missingToken != null)
+                        hasMissingTokens = true;
+                }
+            }
+
+            return lambda;
         }
 
         private LambdaExpressionSyntax ParseLambdaExpression()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -14289,7 +14289,10 @@ tryAgain:
                         }
                         else if (this.CurrentToken.Kind == SyntaxKind.CommaToken || this.IsPossibleExpression())
                         {
-                            list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
+                            if (CurrentKind != SyntaxKind.CommaToken && IsCurrentTokenOnNewline)
+                                list.AddSeparator(SyntaxFactory.FakeToken(SyntaxKind.CommaToken));
+                            else
+                                list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
 
                             // check for exit case after legal trailing comma
                             if (this.CurrentToken.Kind == SyntaxKind.CloseBraceToken)
@@ -14470,7 +14473,10 @@ tryAgain:
                         }
                         else if (IsPossibleExpression() || CurrentToken.Kind == SyntaxKind.CommaToken)
                         {
-                            list.AddSeparator(EatToken(SyntaxKind.CommaToken));
+                            if (CurrentKind != SyntaxKind.CommaToken && IsCurrentTokenOnNewline)
+                                list.AddSeparator(SyntaxFactory.FakeToken(SyntaxKind.CommaToken));
+                            else
+                                list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
 
                             // check for exit case after legal trailing comma
                             if (CurrentToken.Kind == SyntaxKind.CloseBraceToken)
@@ -14594,7 +14600,10 @@ tryAgain:
                         }
                         else if (this.CurrentToken.Kind == SyntaxKind.CommaToken || this.IsInitializerMember())
                         {
-                            list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
+                            if (CurrentKind != SyntaxKind.CommaToken && IsCurrentTokenOnNewline)
+                                list.AddSeparator(SyntaxFactory.FakeToken(SyntaxKind.CommaToken));
+                            else
+                                list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
 
                             // check for exit case after legal trailing comma
                             if (this.CurrentToken.Kind == SyntaxKind.CloseBraceToken)
@@ -14649,7 +14658,7 @@ tryAgain:
         {
             return this.SkipBadSeparatedListTokensWithExpectedKind(ref startToken, list,
                 p => p.CurrentToken.Kind != SyntaxKind.CommaToken && !p.IsPossibleExpression(),
-                p => p.CurrentToken.Kind == SyntaxKind.CloseBraceToken || p.IsTerminator(),
+                p => p.CurrentToken.Kind == SyntaxKind.CloseBraceToken || p.IsTerminator() || (p.IsCurrentTokenOnNewline && (p.IsInitializerMember() || p.IsPossibleExpression())),
                 expected);
         }
 
@@ -14760,7 +14769,11 @@ tryAgain:
                         }
                         else if (this.CurrentToken.Kind == SyntaxKind.CommaToken || this.IsPossibleExpression())
                         {
-                            list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
+                            if (CurrentKind != SyntaxKind.CommaToken && IsCurrentTokenOnNewline)
+                                list.AddSeparator(SyntaxFactory.FakeToken(SyntaxKind.CommaToken));
+                            else
+                                list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
+
                             if (this.CurrentToken.Kind == SyntaxKind.CloseBraceToken)
                             {
                                 closeBraceError = MakeError(this.CurrentToken, ErrorCode.ERR_ExpressionExpected);

--- a/src/Compilers/CSharp/Portable/Rewriters/Impl/DefaultInterfaceImplRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/Impl/DefaultInterfaceImplRewriter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.Rewriters
+{
+    internal sealed class InterfaceObjectCreationRewriter : BoundTreeMethodRewriter<InterfaceObjectCreationRewriter>
+    {
+        public InterfaceObjectCreationRewriter()
+        {
+            VisitBinaryRecursive = true;
+        }
+
+        public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
+        {
+            if (!node.Type.IsInterfaceType())
+                return base.VisitObjectCreationExpression(node);
+
+            // replace with an object creation of the default implementation type
+
+            return base.VisitObjectCreationExpression(node);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Rewriters/Rewriter.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/Rewriter.cs
@@ -171,7 +171,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Rewriters
             MethodSymbol containingSymbol,
             NamedTypeSymbol containingType,
             TypeCompilationState compilationState,
-            DiagnosticBag diagnostics)
+            DiagnosticBag diagnostics
+            )
             where TNode : BoundNode
         {
             // prepare the factory

--- a/src/Compilers/CSharp/Portable/Rewriters/Rewriter.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/Rewriter.cs
@@ -147,20 +147,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Rewriters
     {
         protected SyntheticBoundNodeFactory _F;
         protected DiagnosticBag _diagnostics;
+        protected TypeCompilationState _compilationState;
 
         protected virtual void _ctor(
             MethodSymbol containingMethod,
             NamedTypeSymbol containingType,
             SyntheticBoundNodeFactory factory,
+            TypeCompilationState compilationState,
             DiagnosticBag diagnostics)
         {
             _F = factory;
             _F.CurrentType = containingType;
             _F.CurrentFunction = containingMethod;
             _diagnostics = diagnostics;
+            _compilationState = compilationState;
         }
 
         public SyntheticBoundNodeFactory NodeFactory => _F;
+
+        public CSharpCompilation Compilation => _compilationState.Compilation;
     }
 
     internal abstract class BoundTreeMethodRewriter<TRewriter> : BoundTreeMethodRewriter
@@ -180,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rewriters
 
             // create and init the rewriter
             var rewriter = new TRewriter();
-            rewriter._ctor(containingSymbol, containingType, factory, diagnostics);
+            rewriter._ctor(containingSymbol, containingType, factory, compilationState, diagnostics);
 
             // apply the rewrite
             var newNode = rewriter.Visit(node) as TNode;

--- a/src/Compilers/CSharp/Portable/Rewriters/SyntaxRewritesPass.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/SyntaxRewritesPass.cs
@@ -13,6 +13,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Rewriters
             bool hasTrailingExpression,
             bool originalBodyNested)
         {
+            // rewrite object instantiation of interface types into instantiations of their corresponding default implementation type
+            block = InterfaceObjectCreationRewriter.Rewrite(
+                block,
+                method,
+                method.ContainingType,
+                compilationState,
+                diagnostics
+            );
+
             // rewrite try/catch "inline method" statements to promote variable declarations to the outer scope
             block = MethodInlineTryCatchBlockRewriter.Rewrite(
                 block,

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/GeneratedTypesManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/GeneratedTypesManager.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        private ConcurrentDictionary<string, GeneratedTypeSymbol> _generatedTypesByKey;
+
+        internal GeneratedTypesManager(
+            CSharpCompilation compilation
+            )
+        {
+            Compilation = compilation;
+
+            _generatedTypesByKey = new ConcurrentDictionary<string, GeneratedTypeSymbol>();
+        }
+
+        #region Compilation
+        public CSharpCompilation Compilation { get; protected set; }
+
+        public void CompileGeneratedTypes(MethodCompiler compiler, PEModuleBuilder moduleBeingBuilt, DiagnosticBag diagnostics)
+        {
+            var generatedTypes = GetGeneratedTypes();
+            foreach (var type in generatedTypes)
+            {
+                compiler.Visit(type, null);
+            }
+        }
+        #endregion
+
+        #region Type construction
+        internal ImmutableArray<NamedTypeSymbol> GetGeneratedTypes()
+        {
+            return _generatedTypesByKey.Values.ToImmutableArray<NamedTypeSymbol>();
+        }
+
+        internal GeneratedDefaultInterfaceTypeSymbol GetDefaultInterfaceType(TypeSymbol interfaceType)
+        {
+            var name = $"__DefaultImpl_{interfaceType.Name}";
+            if (!_generatedTypesByKey.TryGetValue(name, out var generatedType))
+                return null;
+            return generatedType as GeneratedDefaultInterfaceTypeSymbol;
+        }
+
+        internal GeneratedTypeBuilder GetDefaultInterfaceTypeBuilder(TypeSymbol interfaceType, DiagnosticBag diagnostics)
+        {
+            // prepare the type descriptor
+            var td = new GeneratedTypeDescriptor();
+            td.Name = $"__DefaultImpl_{interfaceType.Name}";
+            td.TypeKind = TypeKind.Class;
+
+            // return a new builder
+            return new GeneratedTypeBuilder(this, td, GeneratedTypeKind.DefaultInterface, diagnostics);
+        }
+
+        internal GeneratedTypeSymbol GetExistingOrConstructType(GeneratedTypeBuilder typeBuilder)
+        {
+            return _generatedTypesByKey.GetOrAdd(typeBuilder.TypeDescriptor.Name, _ => typeBuilder.Build());
+        }
+        #endregion
+
+        #region Member construction
+        internal PropertyMemberBuilder GetPropertyMemberBuilder()
+        {
+            var pd = new GeneratedPropertyMemberDescriptor();
+            return new PropertyMemberBuilder(pd);
+        }
+        #endregion
+
+        #region Known symbols
+        public Symbol CodeGenNamespace
+            => Compilation.SourceModule.GlobalNamespace;
+
+        public NamedTypeSymbol System_Object
+            => Compilation.GetSpecialType(SpecialType.System_Object);
+
+        public NamedTypeSymbol System_Void
+            => Compilation.GetSpecialType(SpecialType.System_Void);
+
+        public NamedTypeSymbol System_Diagnostics_DebuggerBrowsableState
+            => Compilation.GetWellKnownType(WellKnownType.System_Diagnostics_DebuggerBrowsableState);
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/DefaultInterfaceImplTypeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/DefaultInterfaceImplTypeGenerator.cs
@@ -1,12 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
+using Microsoft.Cci;
 using static Microsoft.CodeAnalysis.CSharp.Symbols.GeneratedTypesManager;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal static class DefaultInterfaceImplTypeGenerator
     {
+        private static readonly MemberSignatureComparer DefaultSignatureComparer = new MemberSignatureComparer(
+            considerName: true,
+            considerExplicitlyImplementedInterfaces: false,
+            considerReturnType: true,
+            considerTypeConstraints: true,
+            considerCallingConvention: true,
+            considerRefKindDifferences: true,
+            typeComparison: TypeCompareKind.AllIgnoreOptions
+        );
+
         internal static GeneratedDefaultInterfaceTypeSymbol Generate(CSharpCompilation compilation, NamedTypeSymbol interfaceType, DiagnosticBag diagnostics = null)
         {
             var ownsDiagnostics = diagnostics == null;
@@ -22,13 +35,68 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // add default constructor
                 tb.WithDefaultConstructor();
 
-                // add all members owned by the interface - but then also generate the members owned by sub members
-                var interfaceMembers = interfaceType.GetMembers();
-                foreach (var interfaceMember in interfaceMembers)
+                // we need to include all members for each interface / base interface in order of priority:
+                // 1. "left to right" in the order of declaration
+                // 2. "top down" by inheritance
+
+                // * members that have exactly "same" definition, can be represented by a single member
+                // * members that match on name but definition differ, must be implemented by "explicit interface members"
+                //   - these interfaces also need to be added in the interface list explicitly
+
+                var memberGroupsByName = new Dictionary<string, MembersGroup>();
+                var interfaces = ImmutableArray.Create(interfaceType).AddRange(interfaceType.GetAllInterfaces());
+                foreach (var it in interfaces)
+                    BuildMemberGroups(it, memberGroupsByName);
+
+                NamedTypeSymbol implicitInterfaceType = null;
+
+                // now build each member entry
+                foreach (var membersGroup in memberGroupsByName.Values.OrderBy(e => e.SortOrder))
                 {
-                    var memberBuilder = GenerateMember(compilation, interfaceType, interfaceMember);
-                    if (memberBuilder != null)
-                        tb.WithMember(memberBuilder);
+                    // check if we can generate as "simple" without needing explicit implementation
+                    if (membersGroup.MemberEntriesBySignature.Count == 0) continue;
+
+                    if (membersGroup.MemberEntriesBySignature.Count == 1)
+                    {
+                        // pick the first member entry, since they all are "equally valid" to generate for
+                        var membersEntry = membersGroup.MemberEntriesBySignature.Values.FirstOrDefault();
+                        var memberEntry = membersEntry.Members.FirstOrDefault();
+                        var member = memberEntry.MemberSymbol;
+
+                        // only a single signature available for this named member group... so just generate a single member!
+                        var memberBuilder = GenerateMember(compilation, interfaceType, member, isExplicitInterface: false);
+                        if (memberBuilder != null)
+                            tb.WithMember(memberBuilder);
+                    }
+                    else
+                    {
+                        var membersEntries = membersGroup.MemberEntriesBySignature.Values.OrderBy(me => me.SortOrder);
+
+                        // pick the first entry / member declaring type as the interface that will be implicit, the remaining ones will be implemented as explicit
+                        if (implicitInterfaceType is null)
+                            implicitInterfaceType = membersEntries.Select(me => me.Members[0].DeclaringTypeSymbol).FirstOrDefault();
+
+                        // we have multiple signatures available for this named member group... we need to implement the members explicitly for each interface!
+                        foreach (var membersEntry in membersEntries)
+                        {
+                            // generate an explicit interface implementation for each of member / declaring types
+                            // however, if the list contains a symbol from the "implicitInterfaceType" then this list of members is implemented implicit
+
+                            var isExplicit = !membersEntry.Members.Any(me => me.DeclaringTypeSymbol.Equals(implicitInterfaceType));
+                            foreach (var memberEntry in membersEntry.Members)
+                            {
+                                var member = memberEntry.MemberSymbol;
+                                var declaringType = memberEntry.DeclaringTypeSymbol;
+                                var memberBuilder = GenerateMember(compilation, declaringType, member, isExplicitInterface: isExplicit);
+                                if (memberBuilder != null)
+                                    tb.WithMember(memberBuilder);
+
+                                // it's enough to implement the first member if not explicit
+                                if (!isExplicit)
+                                    break;
+                            }
+                        }
+                    }
                 }
 
                 // construct the type
@@ -46,16 +114,85 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private static TypeMemberBuilder GenerateMember(CSharpCompilation compilation, NamedTypeSymbol interfaceType, Symbol interfaceMember)
+        private static void BuildMemberGroups(NamedTypeSymbol declaringType, Dictionary<string, MembersGroup> memberGroupsByName = null)
+        {
+            memberGroupsByName ??= new Dictionary<string, MembersGroup>();
+
+            // analyze the member entries
+            var members = declaringType.GetMembers();
+            var memberSortOrder = 0;
+            foreach (var member in members)
+            {
+                if (!IsSupportedMember(member))
+                    continue;
+
+                // group by name
+                var name = member.Name;
+                if (member.IsExplicitInterfaceImplementation())
+                    name = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(name);
+
+                if (!memberGroupsByName.TryGetValue(name, out var membersGroup))
+                {
+                    membersGroup = new MembersGroup() { Name = name, SortOrder = ++memberSortOrder };
+                    memberGroupsByName[name] = membersGroup;
+                }
+
+                // get the members entry that matches the signature of the member
+                var membersEntry = membersGroup.GetOrAddMemberEntryBySignature(member);
+
+                // add the member to the group
+                membersEntry.AddMember(member, declaringType);
+            }
+        }
+
+        private static bool IsSupportedMember(Symbol member)
+        {
+            switch (member.Kind)
+            {
+                case SymbolKind.Property:
+                    return true;
+                case SymbolKind.Method:
+                    {
+                        var method = (MethodSymbol)member;
+
+                        switch (method.MethodKind)
+                        {
+                            case MethodKind.Ordinary:
+                                break;
+                            default:
+                                return false;
+                        }
+
+                        if (!method.IsDefinition) return false;
+
+                        if (method is SourceOrdinaryMethodSymbol ordinarySourceMethod)
+                        {
+                            var (blockBody, exprBody) = ordinarySourceMethod.Bodies;
+                            if (blockBody != null || exprBody != null) return false;
+                        }
+
+                        return true;
+                    }
+                case SymbolKind.Field:
+                case SymbolKind.Event:
+                default:
+                    return false;
+            }
+        }
+
+        private static TypeMemberBuilder GenerateMember(CSharpCompilation compilation, NamedTypeSymbol interfaceType, Symbol interfaceMember, bool isExplicitInterface = false)
         {
             switch (interfaceMember.Kind)
             {
                 case SymbolKind.Property:
-                    return compilation.GeneratedTypesManager.GetPropertyMemberBuilder()
+                    return compilation.GeneratedTypesManager.NewPropertyMember()
                         .FromSymbol((PropertySymbol)interfaceMember)
-                        .ForInterface(interfaceType)
+                        .ForInterface(interfaceType, isExplicitInterface, interfaceMember)
                         .WithAutoBackingField();
                 case SymbolKind.Method:
+                    return compilation.GeneratedTypesManager.NewMethodMember()
+                        .FromSymbol((MethodSymbol)interfaceMember)
+                        .ForInterface(interfaceType, isExplicitInterface, interfaceMember);
                 case SymbolKind.Field:
                 case SymbolKind.Event:
                     break;
@@ -72,6 +209,60 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (defaultImplType is null)
                 defaultImplType = Generate(compilation, interfaceType, diagnostics);
             return defaultImplType;
+        }
+
+        private class MembersGroup
+        {
+            private int _nextMembersEntrySortOrder;
+
+            public MembersGroup()
+            {
+                MemberEntriesBySignature = new Dictionary<Symbol, MembersEntry>(DefaultSignatureComparer);
+            }
+
+            public string Name { get; set; }
+            public int SortOrder { get; set; }
+
+            public Dictionary<Symbol, MembersEntry> MemberEntriesBySignature { get; set; }
+
+            internal MembersEntry GetOrAddMemberEntryBySignature(Symbol member)
+            {
+                if (!MemberEntriesBySignature.TryGetValue(member, out var membersEntry))
+                {
+                    membersEntry = new MembersEntry() { Name = member.Name, SortOrder = _nextMembersEntrySortOrder++ };
+                    MemberEntriesBySignature[member] = membersEntry;
+                }
+
+                return membersEntry;
+            }
+        }
+
+        private class MembersEntry
+        {
+            public MembersEntry()
+            {
+                Members = new List<MemberEntry>();
+            }
+
+            public string Name { get; set; }
+
+            public int SortOrder { get; set; }
+
+            public List<MemberEntry> Members { get; set; }
+
+            internal void AddMember(Symbol memberSymbol, NamedTypeSymbol declaringType)
+            {
+                Members.Add(new MemberEntry() {
+                    MemberSymbol = memberSymbol,
+                    DeclaringTypeSymbol = declaringType
+                });
+            }
+        }
+
+        private class MemberEntry
+        {
+            public NamedTypeSymbol DeclaringTypeSymbol { get; set; }
+            public Symbol MemberSymbol { get; set; }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/DefaultInterfaceImplTypeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/DefaultInterfaceImplTypeGenerator.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using static Microsoft.CodeAnalysis.CSharp.Symbols.GeneratedTypesManager;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal static class DefaultInterfaceImplTypeGenerator
+    {
+        internal static GeneratedDefaultInterfaceTypeSymbol Generate(CSharpCompilation compilation, NamedTypeSymbol interfaceType, DiagnosticBag diagnostics = null)
+        {
+            var ownsDiagnostics = diagnostics == null;
+            if (ownsDiagnostics) diagnostics = DiagnosticBag.GetInstance();
+
+            try
+            {
+                var tb = compilation.GeneratedTypesManager.GetDefaultInterfaceTypeBuilder(interfaceType, diagnostics);
+
+                // set the interface
+                tb.WithInterfaces(interfaceType);
+
+                // add default constructor
+                tb.WithDefaultConstructor();
+
+                // add all members owned by the interface - but then also generate the members owned by sub members
+                var interfaceMembers = interfaceType.GetMembers();
+                foreach (var interfaceMember in interfaceMembers)
+                {
+                    var memberBuilder = GenerateMember(compilation, interfaceType, interfaceMember);
+                    if (memberBuilder != null)
+                        tb.WithMember(memberBuilder);
+                }
+
+                // construct the type
+                var type = tb.ConstructType() as GeneratedDefaultInterfaceTypeSymbol;
+                if (!(type is null))
+                {
+                    type.SynthesizedInterfaceConstructor ??= new SynthesizedInstanceConstructor(interfaceType);
+                    type.InterfaceType ??= interfaceType;
+                }
+                return type;
+            }
+            finally
+            {
+                if (ownsDiagnostics) diagnostics.Free();
+            }
+        }
+
+        private static TypeMemberBuilder GenerateMember(CSharpCompilation compilation, NamedTypeSymbol interfaceType, Symbol interfaceMember)
+        {
+            switch (interfaceMember.Kind)
+            {
+                case SymbolKind.Property:
+                    return compilation.GeneratedTypesManager.GetPropertyMemberBuilder()
+                        .FromSymbol((PropertySymbol)interfaceMember)
+                        .ForInterface(interfaceType)
+                        .WithAutoBackingField();
+                case SymbolKind.Method:
+                case SymbolKind.Field:
+                case SymbolKind.Event:
+                    break;
+                default:
+                    break;
+            }
+
+            return null;
+        }
+
+        internal static GeneratedDefaultInterfaceTypeSymbol GetOrGenerate(CSharpCompilation compilation, NamedTypeSymbol interfaceType, DiagnosticBag diagnostics = null)
+        {
+            var defaultImplType = compilation.GeneratedTypesManager.GetDefaultInterfaceType(interfaceType);
+            if (defaultImplType is null)
+                defaultImplType = Generate(compilation, interfaceType, diagnostics);
+            return defaultImplType;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Members.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Members.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         internal abstract class TypeMemberBuilder
         {
+            internal GeneratedTypesManager Manager { get; set; }
+
             internal abstract Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics);
         }
 
@@ -31,114 +33,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics)
                 => _buildFn(type, td, memberIndex, diagnostics);
-        }
-
-        internal class PropertyMemberBuilder : TypeMemberBuilder
-        {
-            private GeneratedPropertyMemberDescriptor _propDescriptor;
-
-            internal PropertyMemberBuilder(GeneratedPropertyMemberDescriptor propDescriptor)
-            {
-                _propDescriptor = propDescriptor;
-            }
-
-            internal override Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics)
-            {
-                GeneratedFieldSymbol backingField = null;
-                GeneratedTypePropertyGetAccessorSymbol getter = null;
-                GeneratedTypePropertySetAccessorSymbol setter = null;
-
-                // create the backing field for the property
-                if (_propDescriptor.IsAutoProperty)
-                {
-                    var backingFieldDescriptor = new GeneratedFieldMemberDescriptor();
-                    backingFieldDescriptor.Name = GeneratedNames.MakeAnonymousTypeBackingFieldName(_propDescriptor.Name);
-                    backingFieldDescriptor.Type = _propDescriptor.Type;
-                    backingFieldDescriptor.Accessibility = Accessibility.Private;
-                    backingField = new GeneratedFieldSymbol(backingFieldDescriptor);
-
-                    getter = new GeneratedTypePropertyGetAccessorSymbol(_propDescriptor);
-                    setter = new GeneratedTypePropertySetAccessorSymbol(_propDescriptor);
-                }
-
-                // create the property
-                var prop = new GeneratedTypePropertySymbol(
-                    _propDescriptor,
-                    memberIndex
-                );
-
-                // finalize / build the property and the associated
-                prop.Build(
-                    containingType: type,
-                    getter: getter,
-                    setter: setter,
-                    backingField: backingField
-                );
-
-                // build getter / setter for auto properies with backing fields
-                if (_propDescriptor.IsAutoProperty)
-                {
-                    // build the backing field
-                    backingField.Build(
-                        containingType: type,
-                        ownerMemberSymbol: prop,
-                        constantValue: null
-                    );
-
-                    getter.Build(
-                        containingType: type,
-                        property: prop,
-                        bodyGenerator: F => CreateBackingFieldGetterBody(F, backingField)
-                    );
-                    setter.Build(
-                        containingType: type,
-                        property: prop,
-                        bodyGenerator: F => CreateBackingFieldSetterBody(F, backingField, setter.ValueParameter)
-                    );
-                }
-
-                return prop;
-            }
-
-            public PropertyMemberBuilder FromSymbol(PropertySymbol prop)
-            {
-                _propDescriptor.Name = prop.Name;
-                _propDescriptor.Type = prop.TypeWithAnnotations;
-                _propDescriptor.Accessibility = prop.DeclaredAccessibility;
-                return this;
-            }
-
-            public PropertyMemberBuilder WithAutoBackingField()
-            {
-                _propDescriptor.IsAutoProperty = true;
-                return this;
-            }
-
-            public PropertyMemberBuilder ForInterface(NamedTypeSymbol interfaceType)
-            {
-                _propDescriptor.IsAutoProperty = true;
-                _propDescriptor.IsInterfaceImplementation = true;
-                _propDescriptor.Interface = interfaceType;
-                return this;
-            }
-
-            #region Bound node factories
-
-            private BoundStatement CreateBackingFieldSetterBody(SyntheticBoundNodeFactory F, FieldSymbol field, ParameterSymbol valueParam)
-            {
-                var statements = ImmutableArray.Create<BoundStatement>(
-                    F.Assignment(F.Field(F.This(), field), F.Parameter(valueParam)),
-                    F.Return()
-                );
-                return F.Block(statements);
-            }
-
-            private BoundStatement CreateBackingFieldGetterBody(SyntheticBoundNodeFactory F, FieldSymbol field)
-            {
-                return F.Block(F.Return(F.Field(F.This(), field)));
-            }
-
-            #endregion
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Members.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Members.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal abstract class TypeMemberBuilder
+        {
+            internal abstract Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics);
+        }
+
+        class SymbolTypeMemberBuilder : TypeMemberBuilder
+        {
+            private Func<GeneratedTypeSymbol, GeneratedTypeDescriptor, int, DiagnosticBag, Symbol> _buildFn;
+
+            internal SymbolTypeMemberBuilder(Func<GeneratedTypeSymbol, GeneratedTypeDescriptor, int, DiagnosticBag, Symbol> buildFn)
+            {
+                _buildFn = buildFn;
+            }
+
+            internal override Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics)
+                => _buildFn(type, td, memberIndex, diagnostics);
+        }
+
+        internal class PropertyMemberBuilder : TypeMemberBuilder
+        {
+            private GeneratedPropertyMemberDescriptor _propDescriptor;
+
+            internal PropertyMemberBuilder(GeneratedPropertyMemberDescriptor propDescriptor)
+            {
+                _propDescriptor = propDescriptor;
+            }
+
+            internal override Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics)
+            {
+                GeneratedFieldSymbol backingField = null;
+                GeneratedTypePropertyGetAccessorSymbol getter = null;
+                GeneratedTypePropertySetAccessorSymbol setter = null;
+
+                // create the backing field for the property
+                if (_propDescriptor.IsAutoProperty)
+                {
+                    var backingFieldDescriptor = new GeneratedFieldMemberDescriptor();
+                    backingFieldDescriptor.Name = GeneratedNames.MakeAnonymousTypeBackingFieldName(_propDescriptor.Name);
+                    backingFieldDescriptor.Type = _propDescriptor.Type;
+                    backingFieldDescriptor.Accessibility = Accessibility.Private;
+                    backingField = new GeneratedFieldSymbol(backingFieldDescriptor);
+
+                    getter = new GeneratedTypePropertyGetAccessorSymbol(_propDescriptor);
+                    setter = new GeneratedTypePropertySetAccessorSymbol(_propDescriptor);
+                }
+
+                // create the property
+                var prop = new GeneratedTypePropertySymbol(
+                    _propDescriptor,
+                    memberIndex
+                );
+
+                // finalize / build the property and the associated
+                prop.Build(
+                    containingType: type,
+                    getter: getter,
+                    setter: setter,
+                    backingField: backingField
+                );
+
+                // build getter / setter for auto properies with backing fields
+                if (_propDescriptor.IsAutoProperty)
+                {
+                    // build the backing field
+                    backingField.Build(
+                        containingType: type,
+                        ownerMemberSymbol: prop,
+                        constantValue: null
+                    );
+
+                    getter.Build(
+                        containingType: type,
+                        property: prop,
+                        bodyGenerator: F => CreateBackingFieldGetterBody(F, backingField)
+                    );
+                    setter.Build(
+                        containingType: type,
+                        property: prop,
+                        bodyGenerator: F => CreateBackingFieldSetterBody(F, backingField, setter.ValueParameter)
+                    );
+                }
+
+                return prop;
+            }
+
+            public PropertyMemberBuilder FromSymbol(PropertySymbol prop)
+            {
+                _propDescriptor.Name = prop.Name;
+                _propDescriptor.Type = prop.TypeWithAnnotations;
+                _propDescriptor.Accessibility = prop.DeclaredAccessibility;
+                return this;
+            }
+
+            public PropertyMemberBuilder WithAutoBackingField()
+            {
+                _propDescriptor.IsAutoProperty = true;
+                return this;
+            }
+
+            public PropertyMemberBuilder ForInterface(NamedTypeSymbol interfaceType)
+            {
+                _propDescriptor.IsAutoProperty = true;
+                _propDescriptor.IsInterfaceImplementation = true;
+                _propDescriptor.Interface = interfaceType;
+                return this;
+            }
+
+            #region Bound node factories
+
+            private BoundStatement CreateBackingFieldSetterBody(SyntheticBoundNodeFactory F, FieldSymbol field, ParameterSymbol valueParam)
+            {
+                var statements = ImmutableArray.Create<BoundStatement>(
+                    F.Assignment(F.Field(F.This(), field), F.Parameter(valueParam)),
+                    F.Return()
+                );
+                return F.Block(statements);
+            }
+
+            private BoundStatement CreateBackingFieldGetterBody(SyntheticBoundNodeFactory F, FieldSymbol field)
+            {
+                return F.Block(F.Return(F.Field(F.This(), field)));
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.MethodMember.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.MethodMember.cs
@@ -1,0 +1,277 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class MethodMemberBuilder : TypeMemberBuilder
+        {
+            private GeneratedMethodMemberDescriptor _descriptor;
+
+            internal MethodMemberBuilder(GeneratedMethodMemberDescriptor descriptor)
+            {
+                _descriptor = descriptor;
+            }
+
+            internal override Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics)
+            {
+                // create the property
+                var method = new GeneratedOrdinaryMethodSymbol(
+                    _descriptor,
+                    MethodKind.Ordinary
+                );
+
+                // finalize / build the method
+                method.Build(
+                    containingType: type,
+                    bodyGenerator: F => CreateMethodBodyReturningDefaultValue(F, method)
+                );
+
+                return method;
+            }
+
+            public MethodMemberBuilder FromSymbol(MethodSymbol method)
+            {
+                _descriptor.Name = method.Name;
+                _descriptor.Type = method.ReturnTypeWithAnnotations;
+                _descriptor.Arity = method.Arity;
+
+                _descriptor.Accessibility = method.DeclaredAccessibility;
+                _descriptor.IsExtern = method.IsExtern;
+
+                _descriptor.IsStatic = method.IsStatic;
+                _descriptor.IsAsync = method.IsAsync;
+
+                _descriptor.IsVirtual = method.IsVirtual;
+                _descriptor.IsAbstract = method.IsAbstract;
+
+                _descriptor.IsVararg = method.IsVararg;
+
+                _descriptor.TypeParameters = method.TypeParameters;
+
+                if (method.ParameterCount > 0)
+                {
+                    var paramsBuilder = ArrayBuilder<ParameterSymbol>.GetInstance();
+                    for (var i = 0; i < method.ParameterCount; ++i)
+                    {
+                        var p = method.Parameters[i];
+
+                        var pd = new GeneratedParameterDescriptor();
+                        pd.Name = p.Name;
+                        pd.Type = p.TypeWithAnnotations;
+                        pd.IsOptional = p.IsOptional;
+                        pd.IsIn = p.IsMetadataIn;
+                        pd.IsOut = p.IsMetadataOut;
+
+                        pd.RefKind = p.RefKind;
+                        pd.RefCustomModifiers = p.RefCustomModifiers;
+
+                        pd.ExplicitDefaultConstantValue = p.ExplicitDefaultConstantValue;
+
+                        var param = new GeneratedParameterSymbol(pd, i);
+                        paramsBuilder.Add(param);
+                    }
+                    _descriptor.Parameters = paramsBuilder.ToImmutableAndFree();
+                }
+
+                if (method.TypeParameters.Length > 0)
+                {
+                    _descriptor.IsFinal = true;
+
+                    var paramsBuilder = ArrayBuilder<TypeParameterSymbol>.GetInstance();
+                    for (var i = 0; i < method.TypeParameters.Length; ++i)
+                    {
+                        var p = method.TypeParameters[i];
+
+                        var pd = new GeneratedTypeParameterDescriptor();
+                        pd.Name = p.Name;
+                        pd.Variance = p.Variance;
+                        pd.ConstraintTypes = p.ConstraintTypesNoUseSiteDiagnostics;
+
+                        pd.HasConstructorConstraint = p.HasConstructorConstraint;
+                        pd.HasReferenceTypeConstraint = p.HasReferenceTypeConstraint;
+                        pd.HasNotNullConstraint = p.HasNotNullConstraint;
+                        pd.HasValueTypeConstraint = p.HasValueTypeConstraint;
+                        pd.HasUnmanagedTypeConstraint = p.HasUnmanagedTypeConstraint;
+
+                        var param = new GeneratedTypeParameterSymbol(pd, i);
+                        paramsBuilder.Add(param);
+                    }
+                    _descriptor.TypeParameters = paramsBuilder.ToImmutableAndFree();
+                }
+
+                return this;
+            }
+
+            public MethodMemberBuilder ForInterface(NamedTypeSymbol interfaceType, bool isExplicit = false, Symbol interfaceMember = null)
+            {
+                _descriptor.IsInterfaceImplementation = true;
+                _descriptor.Interface = interfaceType;
+                // cannot be abstract for interface implementation
+                _descriptor.IsAbstract = false;
+                // interface implementation requires this
+                _descriptor.IsVirtual = true;
+
+                if (isExplicit)
+                {
+                    _descriptor.Accessibility = Accessibility.Private;
+                    _descriptor.ExplicitInterfaceMember = interfaceMember;
+
+                    // build an explicit interface member name
+                    var name = _descriptor.Name;
+                    if (string.IsNullOrEmpty(name))
+                        name = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(interfaceMember.Name);
+                    name = ExplicitInterfaceHelpers.GetMemberName(name, interfaceType, null);
+                    _descriptor.Name = name;
+                }
+
+                return this;
+            }
+
+            #region Bound node factories
+
+            private BoundStatement CreateMethodBodyReturningDefaultValue(SyntheticBoundNodeFactory F, GeneratedOrdinaryMethodSymbol method)
+            {
+                var statements = ArrayBuilder<BoundStatement>.GetInstance();
+
+                try
+                {
+                    // init parameters - out params
+                    var paramStatements = CreateParamInitStatements(F, method);
+                    statements.AddRange(paramStatements);
+
+                    // finally add the return statement
+                    var returnStat = CreateReturnStatement(F, method);
+                    statements.Add(returnStat);
+
+                    // method body block
+                    return F.Block(statements.ToImmutable());
+                }
+                finally
+                {
+                    statements.Free();
+                }
+            }
+
+            private ImmutableArray<BoundStatement> CreateParamInitStatements(SyntheticBoundNodeFactory F, GeneratedOrdinaryMethodSymbol method)
+            {
+                var outParams = method.Parameters.Where(p => p.IsMetadataOut).ToImmutableArray();
+                if (outParams.Length == 0) return ImmutableArray<BoundStatement>.Empty;
+
+                var statements = ArrayBuilder<BoundStatement>.GetInstance();
+                try
+                {
+                    foreach (var outParam in outParams)
+                    {
+                        var defaultValue = CreateDefaultValueExpression(F, outParam.Type);
+                        var assignStat = F.Assignment(F.Parameter(outParam), defaultValue);
+                        statements.Add(assignStat);
+                    }
+
+                    return statements.ToImmutable();
+                }
+                finally
+                {
+                    statements.Free();
+                }
+            }
+
+            private BoundReturnStatement CreateReturnStatement(SyntheticBoundNodeFactory F, GeneratedOrdinaryMethodSymbol method)
+            {
+                var returnType = method.ReturnType;
+                if (Manager.KnownSymbols.System_Void.Equals(returnType))
+                    return F.Return();
+
+                TypeSymbol? forcedReturnType = null;
+
+                // if the return type has an "original type" annotation, we should use it instead!
+                if (!(_descriptor.Type.AnnotationType is null) && _descriptor.Type.AnnotationTypeKind == TypeAnnotationKind.OriginalType)
+                {
+                    returnType = _descriptor.Type.AnnotationType;
+
+                    // we will have to force the method to accept this
+                    forcedReturnType = returnType;
+
+                    if (Manager.KnownSymbols.System_Void.Equals(returnType))
+                        return F.Return();
+                }
+
+                // we need to return a default value for the method
+                var defaultValue = CreateDefaultValueExpression(F, returnType);
+                if (defaultValue != null)
+                {
+                    return F.Return(expression: defaultValue, forceType: forcedReturnType);
+                }
+                else
+                {
+                    return F.Return();
+                }
+            }
+
+            private BoundExpression CreateDefaultValueExpression(SyntheticBoundNodeFactory F, TypeSymbol returnType)
+            {
+                // we need to return a default value for the method
+                BoundExpression defaultValue = null;
+
+                // handle special cases
+                var hasOriginalDefinition = !(returnType.OriginalDefinition is null);
+
+                if (hasOriginalDefinition && Manager.KnownSymbols.System_Threading_Tasks_Task_T.Equals(returnType.OriginalDefinition))
+                {
+                    // we have a task that returns a value... so return a static return type value
+                    var tp = returnType.GetMemberTypeArgumentsNoUseSiteDiagnostics().FirstOrDefault();
+                    var innerDefaultValue = CreateDefaultValueExpression(F, tp);
+
+                    if (_descriptor.IsAsync)
+                    {
+                        defaultValue = innerDefaultValue;
+                    }
+                    else
+                    {
+                        // "Task.FromResult()"
+                        var fromResultT = Manager.KnownMembers.System_Threading_Tasks_Task_FromResult.Construct(tp);
+                        defaultValue = F.StaticCall(fromResultT, ImmutableArray.Create(innerDefaultValue));
+                    }
+                }
+                else if (Manager.KnownSymbols.System_Threading_Tasks_Task.Equals(returnType))
+                {
+                    if (_descriptor.IsAsync)
+                    {
+                        defaultValue = null;
+                    }
+                    else
+                    {
+                        // we have a task... so return an invocation of the defalt of "Task.CompletedTask"
+                        defaultValue = F.Property(null, Manager.KnownMembers.System_Threading_Tasks_Task_CompletedTask);
+                    }
+                }
+                else if (returnType.IsNullableType())
+                {
+                    // nullable type - return default or null
+                    defaultValue = F.NullOrDefault(returnType);
+                }
+                else
+                {
+                    // non nullable - return default
+                    defaultValue = F.Default(returnType);
+                }
+
+                return defaultValue;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.PropertyMember.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.PropertyMember.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class PropertyMemberBuilder : TypeMemberBuilder
+        {
+            private GeneratedPropertyMemberDescriptor _propDescriptor;
+
+            internal PropertyMemberBuilder(GeneratedPropertyMemberDescriptor propDescriptor)
+            {
+                _propDescriptor = propDescriptor;
+            }
+
+            internal override Symbol Build(GeneratedTypeSymbol type, GeneratedTypeDescriptor td, int memberIndex, DiagnosticBag diagnostics)
+            {
+                GeneratedFieldSymbol backingField = null;
+                GeneratedPropertyGetterAccessor getter = null;
+                GeneratedPropertySetterAccessor setter = null;
+
+                // create the backing field for the property
+                if (_propDescriptor.IsAutoProperty)
+                {
+                    var backingFieldDescriptor = new GeneratedFieldMemberDescriptor();
+                    backingFieldDescriptor.Name = GeneratedNames.MakeAnonymousTypeBackingFieldName(_propDescriptor.Name);
+                    backingFieldDescriptor.Type = _propDescriptor.Type;
+                    backingFieldDescriptor.Accessibility = Accessibility.Private;
+                    backingField = new GeneratedFieldSymbol(backingFieldDescriptor);
+
+                    getter = new GeneratedPropertyGetterAccessor(_propDescriptor);
+                    setter = new GeneratedPropertySetterAccessor(_propDescriptor);
+                }
+
+                // create the property
+                var prop = new GeneratedPropertyMember(
+                    _propDescriptor
+                );
+
+                // finalize / build the property and the associated
+                prop.Build(
+                    containingType: type,
+                    getter: getter,
+                    setter: setter,
+                    backingField: backingField
+                );
+
+                // build getter / setter for auto properies with backing fields
+                if (_propDescriptor.IsAutoProperty)
+                {
+                    // build the backing field
+                    backingField.Build(
+                        containingType: type,
+                        ownerMemberSymbol: prop,
+                        constantValue: null
+                    );
+
+                    getter.Build(
+                        containingType: type,
+                        property: prop,
+                        bodyGenerator: F => CreateBackingFieldGetterBody(F, backingField)
+                    );
+                    setter.Build(
+                        containingType: type,
+                        property: prop,
+                        bodyGenerator: F => CreateBackingFieldSetterBody(F, backingField, setter.ValueParameter)
+                    );
+                }
+
+                return prop;
+            }
+
+            public PropertyMemberBuilder FromSymbol(PropertySymbol prop)
+            {
+                _propDescriptor.Name = prop.Name;
+                _propDescriptor.Type = prop.TypeWithAnnotations;
+                _propDescriptor.Accessibility = prop.DeclaredAccessibility;
+                return this;
+            }
+
+            public PropertyMemberBuilder WithAutoBackingField()
+            {
+                _propDescriptor.IsAutoProperty = true;
+                return this;
+            }
+
+            public PropertyMemberBuilder ForInterface(NamedTypeSymbol interfaceType, bool isExplicit = false, Symbol interfaceMember = null)
+            {
+                _propDescriptor.IsAutoProperty = true;
+                _propDescriptor.IsInterfaceImplementation = true;
+                _propDescriptor.Interface = interfaceType;
+
+                if (isExplicit)
+                {
+                    _propDescriptor.Accessibility = Accessibility.Private;
+                    _propDescriptor.ExplicitInterfaceMember = interfaceMember;
+
+                    // build an explicit interface member name
+                    var name = _propDescriptor.Name;
+                    if (string.IsNullOrEmpty(name))
+                        name = ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(interfaceMember.Name);
+                    name = ExplicitInterfaceHelpers.GetMemberName(name, interfaceType, null);
+                    _propDescriptor.Name = name;
+                }
+
+                return this;
+            }
+
+            #region Bound node factories
+
+            private BoundStatement CreateBackingFieldSetterBody(SyntheticBoundNodeFactory F, FieldSymbol field, ParameterSymbol valueParam)
+            {
+                var statements = ImmutableArray.Create<BoundStatement>(
+                    F.Assignment(F.Field(F.This(), field), F.Parameter(valueParam)),
+                    F.Return()
+                );
+                return F.Block(statements);
+            }
+
+            private BoundStatement CreateBackingFieldGetterBody(SyntheticBoundNodeFactory F, FieldSymbol field)
+            {
+                return F.Block(F.Return(F.Field(F.This(), field)));
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Type.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Type.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal enum GeneratedTypeKind
+    {
+        DefaultInterface
+    }
+
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedTypeBuilder
+        {
+            private GeneratedTypesManager _manager;
+            private GeneratedTypeSymbol _constructedType;
+            private DiagnosticBag _diagnostics;
+
+            private ArrayBuilder<TypeMemberBuilder> _constructors;
+            private ArrayBuilder<TypeMemberBuilder> Constructors
+            {
+                get
+                {
+                    if (_constructors == null)
+                        _constructors = new ArrayBuilder<TypeMemberBuilder>();
+                    return _constructors;
+                }
+            }
+
+            private ArrayBuilder<TypeMemberBuilder> _members;
+            private ArrayBuilder<TypeMemberBuilder> Members
+            {
+                get
+                {
+                    if (_members == null)
+                        _members = new ArrayBuilder<TypeMemberBuilder>();
+                    return _members;
+                }
+            }
+
+            internal GeneratedTypeBuilder(
+                GeneratedTypesManager manager,
+                GeneratedTypeDescriptor typeDescriptor,
+                GeneratedTypeKind genTypeKind,
+                DiagnosticBag diagnostics)
+            {
+                _manager = manager;
+                _diagnostics = diagnostics;
+
+                GenTypeKind = genTypeKind;
+                TypeDescriptor = typeDescriptor;
+            }
+
+            public GeneratedTypeKind GenTypeKind { get; }
+            public GeneratedTypeDescriptor TypeDescriptor { get; }
+
+            public GeneratedTypeSymbol ConstructType()
+            {
+                _constructedType = _manager.GetExistingOrConstructType(this);
+                return _constructedType;
+            }
+
+            #region Configuration helpers - common
+
+            protected internal GeneratedTypeSymbol Build()
+            {
+                GeneratedTypeSymbol type = null;
+
+                if (GenTypeKind == GeneratedTypeKind.DefaultInterface)
+                {
+                    type = new GeneratedDefaultInterfaceTypeSymbol(_manager);
+                }
+                else
+                {
+                    type = new GeneratedTypeSymbol(_manager);
+                }
+
+                // build the members
+                var memberIndex = 0;
+                var membersCount = _members?.Count ?? 0;
+                var constructorsCount = _constructors?.Count ?? 0;
+                var totalMembersCount = membersCount + constructorsCount;
+
+                var members = ArrayBuilder<Symbol>.GetInstance(totalMembersCount);
+                if (membersCount > 0)
+                {
+                    // build the members
+                    foreach (var _member in _members)
+                    {
+                        var member = _member.Build(type, TypeDescriptor, memberIndex++, _diagnostics);
+
+                        if (member is GeneratedTypePropertySymbol propMember)
+                        {
+                            members.Add(propMember);
+                            if (propMember.GetMethod != null)
+                                members.Add(propMember.GetMethod);
+                            if (propMember.SetMethod != null)
+                                members.Add(propMember.SetMethod);
+                            if (propMember.BackingField != null)
+                                members.Add(propMember.BackingField);
+                        }
+                        else
+                        {
+                            members.Add(member);
+                        }
+                    }
+                }
+
+                // build the constructors
+                if (_constructors != null)
+                {
+                    // build the members
+                    foreach (var _constructor in _constructors)
+                    {
+                        var constructor = _constructor.Build(type, TypeDescriptor, memberIndex++, _diagnostics);
+                        members.Add(constructor);
+                    }
+                }
+
+                if(totalMembersCount > 0)
+                    TypeDescriptor.Members = members.ToImmutableAndFree();
+
+                type.Build(TypeDescriptor);
+                return type;
+            }
+
+            public GeneratedTypeBuilder WithContainer(Symbol container)
+            {
+                TypeDescriptor.ContainingSymbol = container;
+                return this;
+            }
+
+            public GeneratedTypeBuilder WithModifiers(
+                bool? isStatic = null,
+                bool? isAbstract = null,
+                bool? isSealed = null,
+                bool? isReadonly = null
+                )
+            {
+                if (isStatic.HasValue) TypeDescriptor.IsStatic = isStatic.Value;
+                if (isAbstract.HasValue) TypeDescriptor.IsAbstract = isAbstract.Value;
+                if (isSealed.HasValue) TypeDescriptor.IsSealed = isSealed.Value;
+                if (isReadonly.HasValue) TypeDescriptor.IsReadOnly = isReadonly.Value;
+                return this;
+            }
+
+            public GeneratedTypeBuilder WithBaseType(NamedTypeSymbol baseType)
+            {
+                TypeDescriptor.BaseType = baseType;
+                return this;
+            }
+
+            public GeneratedTypeBuilder WithInterfaces(params NamedTypeSymbol[] interfaces)
+            {
+                TypeDescriptor.Interfaces = interfaces.ToImmutableArray();
+                return this;
+            }
+
+            public GeneratedTypeBuilder WithSyntax(SyntaxReference syntaxReference)
+            {
+                TypeDescriptor.DeclaringSyntaxReferences = ImmutableArray.Create(syntaxReference);
+                TypeDescriptor.Locations = ImmutableArray.Create(syntaxReference.GetLocation());
+                return this;
+            }
+
+            #endregion
+
+            #region Configuration helpers - Members
+
+            public GeneratedTypeBuilder WithDefaultConstructor()
+            {
+                return WithConstructor(new SymbolTypeMemberBuilder((t, td, memberIndex, diagnostics) => {
+                    if (td.TypeKind == TypeKind.Submission)
+                        return new SynthesizedSubmissionConstructor(t, diagnostics);
+                    return new SynthesizedInstanceConstructor(t);
+                }));
+            }
+
+            public GeneratedTypeBuilder WithConstructor(TypeMemberBuilder constructorBuilder)
+            {
+                Constructors.Add(constructorBuilder);
+                return this;
+            }
+
+            public GeneratedTypeBuilder WithMember(TypeMemberBuilder memberBuilder)
+            {
+                Members.Add(memberBuilder);
+                return this;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Type.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Type.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         var member = _member.Build(type, TypeDescriptor, memberIndex++, _diagnostics);
 
-                        if (member is GeneratedTypePropertySymbol propMember)
+                        if (member is GeneratedPropertyMember propMember)
                         {
                             members.Add(propMember);
                             if (propMember.GetMethod != null)

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.TypeSymbol.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedDefaultInterfaceTypeSymbol : GeneratedTypeSymbol
+        {
+            internal GeneratedDefaultInterfaceTypeSymbol(
+                GeneratedTypesManager manager
+                )
+                : base(manager)
+            {
+            }
+
+            public SynthesizedInstanceConstructor SynthesizedInterfaceConstructor { get; set; }
+            public NamedTypeSymbol InterfaceType { get; set; }
+        }
+
+        internal class GeneratedTypeSymbol : NamedTypeSymbol
+        {
+            private GeneratedTypeDescriptor _typeDescriptor;
+
+            private HashSet<string> _memberNames;
+            private MultiDictionary<string, Symbol> _membersByName;
+            private ImmutableArray<NamedTypeSymbol> _typeMembers;
+
+            internal GeneratedTypeSymbol(GeneratedTypesManager manager)
+            {
+                Manager = manager;
+            }
+
+            internal GeneratedTypesManager Manager { get; }
+
+            internal void Build(GeneratedTypeDescriptor typeDescriptor)
+            {
+                _typeDescriptor = typeDescriptor;
+                _memberNames = new HashSet<string>();
+                _membersByName = new MultiDictionary<string, Symbol>();
+
+                var typeMembersBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+                if (_typeDescriptor.Members != null)
+                {
+                    foreach (var member in _typeDescriptor.Members)
+                    {
+                        _memberNames.Add(member.Name);
+                        _membersByName.Add(member.Name, member);
+
+                        if (member is NamedTypeSymbol typeMember)
+                            typeMembersBuilder.Add(typeMember);
+                    }
+                }
+                _typeMembers = typeMembersBuilder.ToImmutableAndFree();
+            }
+
+            #region Implementation
+
+            // Type kind
+            public override TypeKind TypeKind => _typeDescriptor.TypeKind;
+            internal override bool IsInterface => TypeKind == TypeKind.Interface;
+
+            // Parent namespace / type
+            public override Symbol ContainingSymbol
+                => _typeDescriptor.ContainingSymbol ?? Manager.CodeGenNamespace;
+
+            // Visibility
+            public override Accessibility DeclaredAccessibility
+                => _typeDescriptor.Accessibility ?? Accessibility.Internal;
+
+            // Modifiers
+            public override bool IsStatic
+                => _typeDescriptor.IsStatic;
+
+            public override bool IsAbstract
+                => _typeDescriptor.IsAbstract;
+
+            public override bool IsSealed
+                => _typeDescriptor.IsSealed;
+
+            public override bool IsReadOnly
+                => _typeDescriptor.IsReadOnly;
+
+            // Name
+            public override string Name => _typeDescriptor.Name;
+            public override string MetadataName => string.Empty;
+            internal override bool MangleName => false;
+            internal override bool HasSpecialName => false;
+
+            // Type parameters
+            public override ImmutableArray<TypeParameterSymbol> TypeParameters
+                => _typeDescriptor.TypeParameters ?? ImmutableArray<TypeParameterSymbol>.Empty;
+
+            internal override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotationsNoUseSiteDiagnostics
+                => ImmutableArray<TypeWithAnnotations>.Empty;
+
+            // Base type & interfaces
+            internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
+                => _typeDescriptor.BaseType ?? Manager.System_Object;
+
+            internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved)
+                => _typeDescriptor.BaseType ?? Manager.System_Object;
+
+            internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<TypeSymbol> basesBeingResolved)
+                => _typeDescriptor.Interfaces ?? ImmutableArray<NamedTypeSymbol>.Empty;
+
+            internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved = null)
+                => _typeDescriptor.Interfaces ?? ImmutableArray<NamedTypeSymbol>.Empty;
+
+            internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit()
+                => InterfacesNoUseSiteDiagnostics();
+
+            // Members
+            public override IEnumerable<string> MemberNames => _memberNames;
+
+            public override ImmutableArray<Symbol> GetMembers()
+                => _typeDescriptor.Members ?? ImmutableArray<Symbol>.Empty;
+
+            public override ImmutableArray<Symbol> GetMembers(string name)
+            {
+                var symbols = _membersByName[name];
+                var builder = ArrayBuilder<Symbol>.GetInstance(symbols.Count);
+
+                foreach (var symbol in symbols)
+                    builder.Add(symbol);
+
+                return builder.ToImmutableAndFree();
+            }
+
+            public override ImmutableArray<NamedTypeSymbol> GetTypeMembers()
+                => _typeMembers;
+
+            public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name)
+                => _typeMembers.IsEmpty ? ImmutableArray<NamedTypeSymbol>.Empty : _typeMembers.Where(m => m.Name == name).ToImmutableArray();
+
+            public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity)
+                => _typeMembers.IsEmpty ? ImmutableArray<NamedTypeSymbol>.Empty : _typeMembers.Where(m => m.Name == name && m.Arity == arity).ToImmutableArray();
+
+            internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers()
+                => GetMembersUnordered();
+
+            internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name)
+                => GetMembers(name);
+
+            internal override IEnumerable<FieldSymbol> GetFieldsToEmit()
+                => GetMembers().Where(m => m.Kind == SymbolKind.Field).Cast<FieldSymbol>();
+
+            public override bool AreLocalsZeroed
+            {
+                get
+                {
+                    switch (TypeKind)
+                    {
+                        case TypeKind.Interface:
+                        case TypeKind.Delegate:
+                        case TypeKind.Enum:
+                        case TypeKind.Module:
+                        case TypeKind.Array:
+                        case TypeKind.Pointer:
+                        case TypeKind.FunctionPointer:
+                        case TypeKind.Error:
+                        case TypeKind.TypeParameter:
+                        case TypeKind.Unknown:
+                            return false;
+                        default:
+                            return true;
+                    }
+                }
+            }
+
+            // Syntax declaration
+            public override ImmutableArray<Location> Locations
+                => _typeDescriptor.Locations ?? ImmutableArray<Location>.Empty;
+
+            public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+                => _typeDescriptor.DeclaringSyntaxReferences ?? ImmutableArray<SyntaxReference>.Empty;
+
+            #endregion
+
+            #region Default overrides
+            public override int Arity => 0;
+
+            public override NamedTypeSymbol ConstructedFrom => this;
+
+            public override bool MightContainExtensionMethods => false;
+
+            public override bool IsSerializable => false;
+
+            public override bool IsRefLikeType => false;
+
+            internal override bool HasCodeAnalysisEmbeddedAttribute => false;
+
+            internal override bool IsComImport => false;
+
+            internal override bool IsWindowsRuntimeImport => false;
+
+            internal override bool ShouldAddWinRTMembers => false;
+
+            internal override TypeLayout Layout => default;
+
+            internal override CharSet MarshallingCharSet => DefaultMarshallingCharSet;
+
+            internal override bool HasDeclarativeSecurity => false;
+
+            internal override NamedTypeSymbol NativeIntegerUnderlyingType => null;
+
+            internal override ObsoleteAttributeData ObsoleteAttributeData => null;
+
+            protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData) => null;
+
+            internal override NamedTypeSymbol AsNativeInteger() => null;
+
+            internal override ImmutableArray<string> GetAppliedConditionalSymbols() => ImmutableArray<string>.Empty;
+
+            internal override AttributeUsageInfo GetAttributeUsageInfo() => AttributeUsageInfo.Null;
+
+            internal override IEnumerable<SecurityAttribute> GetSecurityInformation()
+                => Enumerable.Empty<SecurityAttribute>();
+
+            #endregion
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.TypeSymbol.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Parent namespace / type
             public override Symbol ContainingSymbol
-                => _typeDescriptor.ContainingSymbol ?? Manager.CodeGenNamespace;
+                => _typeDescriptor.ContainingSymbol ?? Manager.KnownSymbols.CodeGenNamespace;
 
             // Visibility
             public override Accessibility DeclaredAccessibility
@@ -106,10 +106,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Base type & interfaces
             internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
-                => _typeDescriptor.BaseType ?? Manager.System_Object;
+                => _typeDescriptor.BaseType ?? Manager.KnownSymbols.System_Object;
 
             internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved)
-                => _typeDescriptor.BaseType ?? Manager.System_Object;
+                => _typeDescriptor.BaseType ?? Manager.KnownSymbols.System_Object;
 
             internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<TypeSymbol> basesBeingResolved)
                 => _typeDescriptor.Interfaces ?? ImmutableArray<NamedTypeSymbol>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.Descriptor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.Descriptor.cs
@@ -61,6 +61,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public bool IsOut { get; set; }
             public bool IsOptional { get; set; }
             public bool IsParams { get; set; }
+
+            public RefKind? RefKind { get; set; }
+            public ImmutableArray<CustomModifier>? RefCustomModifiers { get; set; }
+
+            public ConstantValue ExplicitDefaultConstantValue { get; set; }
+        }
+
+        internal class GeneratedTypeParameterDescriptor : GeneratedSymbolDescriptor
+        {
+            public string Name { get; set; }
+
+            public VarianceKind Variance { get; internal set; }
+
+            public ImmutableArray<TypeWithAnnotations>? ConstraintTypes { get; internal set; }
+
+            public bool HasConstructorConstraint { get; set; }
+            public bool HasReferenceTypeConstraint { get; set; }
+            public bool HasNotNullConstraint { get; set; }
+            public bool HasValueTypeConstraint { get; set; }
+            public bool HasUnmanagedTypeConstraint { get; set; }
         }
 
         internal class GeneratedMemberDescriptor : GeneratedSymbolDescriptor
@@ -87,11 +107,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public bool IsVolatile { get; set; }
             public bool IsConst { get; set; }
 
-            public bool IsExplicitInterfaceImplementation { get; set; }
-            public Symbol ExplicitInterface { get; set; }
-
             public bool IsInterfaceImplementation { get; set; }
             public Symbol Interface { get; set; }
+            public Symbol ExplicitInterfaceMember { get; set; }
 
             public TypeWithAnnotations Type { get; set; }
             public ImmutableArray<TypeParameterSymbol>? TypeParameters { get; set; }
@@ -100,6 +118,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal class GeneratedMethodMemberDescriptor : GeneratedMemberDescriptor
         {
+            public int Arity { get; set; }
+            public ImmutableArray<ParameterSymbol>? Parameters { get; set; }
         }
 
         internal class GeneratedFieldMemberDescriptor : GeneratedMemberDescriptor

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.Descriptor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.Descriptor.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedSymbolDescriptor
+        {
+            internal GeneratedSymbolDescriptor()
+            {
+                IsDebuggerHidden = true;
+                IsDebuggerBrowsable = false;
+            }
+
+            public ImmutableArray<SyntaxReference>? DeclaringSyntaxReferences { get; set; }
+            public ImmutableArray<Location>? Locations { get; set; }
+
+            public bool IsDebuggerHidden { get; set; }
+            public bool IsDebuggerBrowsable { get; set; }
+        }
+
+        internal class GeneratedTypeDescriptor : GeneratedSymbolDescriptor
+        {
+            public TypeKind TypeKind { get; set; }
+
+            public string Name { get; set; }
+
+            public Accessibility? Accessibility { get; set; }
+            public bool IsStatic { get; set; }
+            public bool IsAbstract { get; set; }
+            public bool IsSealed { get; set; }
+            public bool IsReadOnly { get; set; }
+
+            public ImmutableArray<TypeParameterSymbol>? TypeParameters { get; set; }
+            public NamedTypeSymbol? BaseType { get; set; }
+            public ImmutableArray<NamedTypeSymbol>? Interfaces { get; set; }
+
+            public Symbol ContainingSymbol { get; set; }
+            public ImmutableArray<Symbol>? Members { get; set; }
+        }
+
+
+        internal class GeneratedParameterDescriptor : GeneratedSymbolDescriptor
+        {
+            public string Name { get; set; }
+            public TypeWithAnnotations Type { get; set; }
+
+            public bool IsIn { get; set; }
+            public bool IsOut { get; set; }
+            public bool IsOptional { get; set; }
+            public bool IsParams { get; set; }
+        }
+
+        internal class GeneratedMemberDescriptor : GeneratedSymbolDescriptor
+        {
+            public string Name { get; set; }
+
+            public Accessibility? Accessibility { get; set; }
+            public bool IsExtern { get; set; }
+
+            public bool IsStatic { get; set; }
+            public bool IsAsync { get; set; }
+
+            public bool IsAbstract { get; set; }
+            public bool IsVirtual { get; set; }
+            public bool IsOverride { get; set; }
+
+            public bool IsFinal { get; set; }
+            public bool IsSealed { get; set; }
+            public bool IsReadOnly { get; set; }
+
+            public bool IsVararg { get; set; }
+            public bool IsInitOnly { get; set; }
+
+            public bool IsVolatile { get; set; }
+            public bool IsConst { get; set; }
+
+            public bool IsExplicitInterfaceImplementation { get; set; }
+            public Symbol ExplicitInterface { get; set; }
+
+            public bool IsInterfaceImplementation { get; set; }
+            public Symbol Interface { get; set; }
+
+            public TypeWithAnnotations Type { get; set; }
+            public ImmutableArray<TypeParameterSymbol>? TypeParameters { get; set; }
+            public ImmutableArray<TypeWithAnnotations>? TypeArguments { get; set; }
+        }
+
+        internal class GeneratedMethodMemberDescriptor : GeneratedMemberDescriptor
+        {
+        }
+
+        internal class GeneratedFieldMemberDescriptor : GeneratedMemberDescriptor
+        {
+        }
+
+        internal class GeneratedPropertyMemberDescriptor : GeneratedMemberDescriptor
+        {
+            public bool IsAutoProperty { get; set; }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.FieldSymbol.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        private class GeneratedFieldSymbol : FieldSymbol
+        {
+            private NamedTypeSymbol _containingType;
+            private ConstantValue _constantValue;
+
+            public GeneratedFieldSymbol(GeneratedFieldMemberDescriptor descriptor)
+            {
+                Descriptor = descriptor;
+            }
+
+            protected GeneratedFieldMemberDescriptor Descriptor { get; }
+
+            public virtual GeneratedFieldSymbol Build(NamedTypeSymbol containingType, Symbol ownerMemberSymbol, ConstantValue constantValue)
+            {
+                // the member that owns this field - the "associated" member / the member to which this field is "attached"
+                // - for "backing fields" this would be the "property symbol"
+                OwnerMemberSymbol = ownerMemberSymbol;
+                _containingType = containingType;
+                return this;
+            }
+
+            protected GeneratedTypesManager Manager
+            {
+                get
+                {
+                    var generatedType = _containingType as GeneratedTypeSymbol;
+                    return ((object)generatedType != null) ? generatedType.Manager : ((GeneratedTypeSymbol)_containingType).Manager;
+                }
+            }
+
+            public Symbol OwnerMemberSymbol { get; internal set; }
+
+            internal override TypeWithAnnotations GetFieldType(ConsList<FieldSymbol> fieldsBeingBound)
+                => Descriptor.Type;
+
+            public override string Name
+                => Descriptor.Name;
+
+            public override FlowAnalysisAnnotations FlowAnalysisAnnotations
+                => FlowAnalysisAnnotations.None;
+
+            internal override bool HasSpecialName
+                => false;
+
+            internal override bool HasRuntimeSpecialName
+                => false;
+
+            internal override bool IsNotSerialized
+                => false;
+
+            internal override MarshalPseudoCustomAttributeData MarshallingInformation
+                => null;
+
+            internal override int? TypeLayoutOffset
+                => null;
+
+            public override Symbol AssociatedSymbol
+                => OwnerMemberSymbol;
+
+            public override bool IsReadOnly
+                => Descriptor.IsReadOnly;
+
+            public override bool IsVolatile
+                => Descriptor.IsVolatile;
+
+            public override bool IsConst
+                => Descriptor.IsConst;
+
+            internal sealed override ObsoleteAttributeData ObsoleteAttributeData
+                => null;
+
+            internal override ConstantValue GetConstantValue(ConstantFieldsInProgress inProgress, bool earlyDecodingWellKnownAttributes)
+                => _constantValue;
+
+            public override Symbol ContainingSymbol
+                => _containingType;
+
+            public override NamedTypeSymbol ContainingType
+                => _containingType;
+
+            public override ImmutableArray<Location> Locations
+                => Descriptor.Locations ?? ImmutableArray<Location>.Empty;
+
+            public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+                => Descriptor.DeclaringSyntaxReferences ?? ImmutableArray<SyntaxReference>.Empty;
+
+            public override Accessibility DeclaredAccessibility
+                => Descriptor.Accessibility ?? Accessibility.Internal;
+
+            public override bool IsStatic
+                => Descriptor.IsStatic;
+
+            public override bool IsImplicitlyDeclared
+                => true;
+
+            internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+            {
+                base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+
+                if (!Descriptor.IsDebuggerBrowsable)
+                {
+                    AddSynthesizedAttribute(ref attributes, Manager.Compilation.TrySynthesizeAttribute(
+                        WellKnownMember.System_Diagnostics_DebuggerBrowsableAttribute__ctor,
+                        ImmutableArray.Create(new TypedConstant(Manager.System_Diagnostics_DebuggerBrowsableState, TypedConstantKind.Enum, DebuggerBrowsableState.Never)))
+                    );
+                }
+
+                if (Descriptor.IsDebuggerHidden)
+                {
+                    AddSynthesizedAttribute(ref attributes, Manager.Compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor));
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.FieldSymbol.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     AddSynthesizedAttribute(ref attributes, Manager.Compilation.TrySynthesizeAttribute(
                         WellKnownMember.System_Diagnostics_DebuggerBrowsableAttribute__ctor,
-                        ImmutableArray.Create(new TypedConstant(Manager.System_Diagnostics_DebuggerBrowsableState, TypedConstantKind.Enum, DebuggerBrowsableState.Never)))
+                        ImmutableArray.Create(new TypedConstant(Manager.KnownSymbols.System_Diagnostics_DebuggerBrowsableState, TypedConstantKind.Enum, DebuggerBrowsableState.Never)))
                     );
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.Method.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.Method.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedOrdinaryMethodSymbol : SynthesizedMethodBase
+        {
+            private Func<SyntheticBoundNodeFactory, BoundStatement> _bodyGenerator;
+
+            internal GeneratedOrdinaryMethodSymbol(
+                GeneratedMethodMemberDescriptor descriptor,
+                MethodKind methodKind = MethodKind.Ordinary
+                )
+                : base(descriptor, methodKind)
+            {
+                _methodKind = methodKind;
+            }
+
+            public new GeneratedMethodMemberDescriptor Descriptor => base.Descriptor as GeneratedMethodMemberDescriptor;
+
+            public virtual GeneratedOrdinaryMethodSymbol Build(
+                NamedTypeSymbol containingType,
+                Func<SyntheticBoundNodeFactory, BoundStatement> bodyGenerator
+                )
+            {
+                base.Build(containingType);
+                _bodyGenerator = bodyGenerator;
+                return this;
+            }
+
+            internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
+            {
+                var factory = CreateBoundNodeFactory(compilationState, diagnostics);
+                var body = _bodyGenerator(factory);
+                factory.CloseMethod(body);
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.MethodBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.MethodBase.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal abstract class SynthesizedMethodBase : SynthesizedInstanceMethodSymbol
+        {
+            protected NamedTypeSymbol _containingType;
+
+            public SynthesizedMethodBase(GeneratedMethodMemberDescriptor descriptor)
+            {
+                Descriptor = descriptor;
+            }
+
+            public GeneratedMethodMemberDescriptor Descriptor { get; protected set; }
+
+            protected GeneratedTypesManager Manager
+            {
+                get
+                {
+                    var generatedType = _containingType as GeneratedTypeSymbol;
+                    return ((object)generatedType != null) ? generatedType.Manager : ((GeneratedTypeSymbol)_containingType).Manager;
+                }
+            }
+
+            #region Implementation
+
+            // Parent namespace / type
+            public override Symbol ContainingSymbol
+                => _containingType;
+
+            public override NamedTypeSymbol ContainingType
+                => _containingType;
+
+            public override bool HidesBaseMethodsByName
+                => false;
+
+            // Visibility
+            public override Accessibility DeclaredAccessibility
+                => Descriptor.Accessibility ?? Accessibility.Internal;
+
+            // Modifiers
+            public override bool IsStatic
+                => Descriptor.IsStatic;
+
+            public override bool IsAbstract
+                => Descriptor.IsAbstract;
+
+            public override bool IsSealed
+                => Descriptor.IsSealed;
+
+            public override bool IsVirtual
+                => Descriptor.IsVirtual;
+
+            public override bool IsAsync
+                => Descriptor.IsAsync;
+
+            internal override bool IsExplicitInterfaceImplementation
+                => Descriptor.IsExplicitInterfaceImplementation;
+
+            public override bool IsVararg
+                => Descriptor.IsVararg;
+
+            public override bool IsExtern
+                => Descriptor.IsExtern;
+
+            // Type parameters
+            public override ImmutableArray<TypeParameterSymbol> TypeParameters
+                => Descriptor.TypeParameters ?? ImmutableArray<TypeParameterSymbol>.Empty;
+
+            public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
+                => Descriptor.TypeArguments ?? ImmutableArray<TypeWithAnnotations>.Empty;
+
+            // Name
+            public override string Name
+                => Descriptor.Name;
+
+            // Syntax declaration
+            public override ImmutableArray<Location> Locations
+                => Descriptor.Locations ?? ImmutableArray<Location>.Empty;
+
+            public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+                => Descriptor.DeclaringSyntaxReferences ?? ImmutableArray<SyntaxReference>.Empty;
+
+            #endregion
+
+            #region Helpers
+            protected SyntheticBoundNodeFactory CreateBoundNodeFactory(TypeCompilationState compilationState, DiagnosticBag diagnostics)
+            {
+                var F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
+                F.CurrentFunction = this;
+                return F;
+            }
+            #endregion
+
+            #region Default overrides
+
+            internal override bool GenerateDebugInfo
+                => false;
+
+            public override int Arity
+                => 0;
+
+            internal override System.Reflection.MethodImplAttributes ImplementationAttributes
+                => default;
+
+            internal override Cci.CallingConvention CallingConvention
+                => Cci.CallingConvention.HasThis;
+
+            public override bool IsExtensionMethod
+                => false;
+
+            public override FlowAnalysisAnnotations ReturnTypeFlowAnalysisAnnotations
+                => FlowAnalysisAnnotations.None;
+
+            public override ImmutableHashSet<string> ReturnNotNullIfParameterNotNull
+                => ImmutableHashSet<string>.Empty;
+
+            public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations
+                => ImmutableArray<MethodSymbol>.Empty;
+
+            // methods on classes are never 'readonly'
+            internal override bool IsDeclaredReadOnly
+                => Descriptor.IsReadOnly;
+
+            internal override bool IsInitOnly
+                => Descriptor.IsInitOnly;
+
+            public override ImmutableArray<CustomModifier> RefCustomModifiers
+                => ImmutableArray<CustomModifier>.Empty;
+
+            public override Symbol AssociatedSymbol
+                => null;
+
+            internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+                => Descriptor.IsInterfaceImplementation;
+
+            internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+            {
+                base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+
+                if (!Descriptor.IsDebuggerBrowsable)
+                {
+                    AddSynthesizedAttribute(ref attributes, Manager.Compilation.TrySynthesizeAttribute(
+                        WellKnownMember.System_Diagnostics_DebuggerBrowsableAttribute__ctor,
+                        ImmutableArray.Create(new TypedConstant(Manager.System_Diagnostics_DebuggerBrowsableState, TypedConstantKind.Enum, DebuggerBrowsableState.Never)))
+                    );
+                }
+
+                if (Descriptor.IsDebuggerHidden)
+                {
+                    AddSynthesizedAttribute(ref attributes, Manager.Compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor));
+                }
+            }
+
+            internal override bool RequiresSecurityObject
+                => false;
+
+            public override DllImportData GetDllImportData()
+                => null;
+
+            internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation
+                => null;
+
+            internal override bool HasDeclarativeSecurity
+                => false;
+
+            internal override IEnumerable<Cci.SecurityAttribute> GetSecurityInformation()
+                => throw ExceptionUtilities.Unreachable;
+
+            internal override ImmutableArray<string> GetAppliedConditionalSymbols()
+                => ImmutableArray<string>.Empty;
+
+            internal override bool SynthesizesLoweredBoundBody
+                => true;
+
+            internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
+                => throw ExceptionUtilities.Unreachable;
+
+            #endregion
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.MethodBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.MethodBase.cs
@@ -64,6 +64,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public override bool IsVirtual
                 => Descriptor.IsVirtual;
 
+            public override bool IsOverride
+                => Descriptor.IsOverride;
+
             public override bool IsAsync
                 => Descriptor.IsAsync;
 
@@ -87,6 +90,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public override string Name
                 => Descriptor.Name;
 
+            internal override bool HasSpecialName
+                => false;
+
             // Syntax declaration
             public override ImmutableArray<Location> Locations
                 => Descriptor.Locations ?? ImmutableArray<Location>.Empty;
@@ -106,6 +112,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             #endregion
 
             #region Default overrides
+
+            public override RefKind RefKind
+                => RefKind.None;
 
             internal override bool GenerateDebugInfo
                 => false;
@@ -146,6 +155,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
                 => Descriptor.IsInterfaceImplementation;
+
+            internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false)
+                => Descriptor.IsVirtual;
+
+            internal override bool IsMetadataFinal
+                => Descriptor.IsFinal;
 
             internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.ParameterSymbol.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedParameterSymbol : ParameterSymbol
+        {
+            private int _ordinal;
+
+            internal GeneratedParameterSymbol(GeneratedParameterDescriptor descriptor, int ordinal)
+            {
+                Descriptor = descriptor;
+
+                _ordinal = ordinal;
+            }
+
+            protected GeneratedParameterDescriptor Descriptor { get; }
+
+            public virtual GeneratedParameterSymbol Build(MethodSymbol method)
+            {
+                MethodSymbol = method;
+                return this;
+            }
+
+            public MethodSymbol MethodSymbol { get; protected set; }
+
+            public override string Name
+                => Descriptor.Name;
+
+            public override TypeWithAnnotations TypeWithAnnotations
+                => Descriptor.Type;
+
+            public override RefKind RefKind
+                => RefKind.None;
+
+            public override bool IsDiscard
+                => false;
+
+            public override ImmutableArray<CustomModifier> RefCustomModifiers
+                => ImmutableArray<CustomModifier>.Empty;
+
+            public override int Ordinal
+                => _ordinal;
+
+            public override bool IsParams
+                => Descriptor.IsParams;
+
+            public override Symbol ContainingSymbol
+                => MethodSymbol;
+
+            public override ImmutableArray<Location> Locations
+                => Descriptor.Locations ?? ImmutableArray<Location>.Empty;
+
+            public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+                => Descriptor.DeclaringSyntaxReferences ?? ImmutableArray<SyntaxReference>.Empty;
+
+            internal override MarshalPseudoCustomAttributeData MarshallingInformation
+                => null;
+
+            internal override bool IsMetadataOptional
+                => Descriptor.IsOptional;
+
+            internal override bool IsMetadataIn
+                => Descriptor.IsIn;
+
+            internal override bool IsMetadataOut
+                => Descriptor.IsOut;
+
+            internal override ConstantValue ExplicitDefaultConstantValue
+                => ConstantValue.Unset;
+
+            internal override bool IsIDispatchConstant
+                => false;
+
+            internal override bool IsIUnknownConstant
+                => false;
+
+            internal override bool IsCallerFilePath
+                => false;
+
+            internal override bool IsCallerLineNumber
+                => false;
+
+            internal override bool IsCallerMemberName
+                => false;
+
+            internal override FlowAnalysisAnnotations FlowAnalysisAnnotations
+                => FlowAnalysisAnnotations.None;
+
+            internal override ImmutableHashSet<string> NotNullIfParameterNotNull
+                => ImmutableHashSet<string>.Empty;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.ParameterSymbol.cs
@@ -44,13 +44,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 => Descriptor.Type;
 
             public override RefKind RefKind
-                => RefKind.None;
+                => Descriptor.RefKind ?? RefKind.None;
 
             public override bool IsDiscard
                 => false;
 
             public override ImmutableArray<CustomModifier> RefCustomModifiers
-                => ImmutableArray<CustomModifier>.Empty;
+                => Descriptor.RefCustomModifiers ?? ImmutableArray<CustomModifier>.Empty;
 
             public override int Ordinal
                 => _ordinal;
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 => Descriptor.IsOut;
 
             internal override ConstantValue ExplicitDefaultConstantValue
-                => ConstantValue.Unset;
+                => Descriptor.ExplicitDefaultConstantValue;
 
             internal override bool IsIDispatchConstant
                 => false;

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbol.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 => PropDescriptor.IsExplicitInterfaceImplementation;
 
             public sealed override bool IsExtern
-                => false;
+                => PropDescriptor.IsExtern;
 
             // Type
             public override TypeWithAnnotations TypeWithAnnotations

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbol.cs
@@ -16,28 +16,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal partial class GeneratedTypesManager
     {
-        internal class GeneratedTypePropertySymbol : PropertySymbol
+        internal class GeneratedPropertyMember : PropertySymbol
         {
             private NamedTypeSymbol _containingType;
-            private int _memberIndex;
 
-            private GeneratedTypePropertyAccessorSymbol _getter;
-            private GeneratedTypePropertyAccessorSymbol _setter;
+            private GeneratedProperteyAccessor _getter;
+            private GeneratedProperteyAccessor _setter;
             private FieldSymbol _backingField;
 
-            internal GeneratedTypePropertySymbol(
-                GeneratedPropertyMemberDescriptor descriptor,
-                int index
+            internal GeneratedPropertyMember(
+                GeneratedPropertyMemberDescriptor descriptor
                 )
             {
                 PropDescriptor = descriptor;
-                _memberIndex = index;
             }
 
-            public virtual GeneratedTypePropertySymbol Build(
+            public virtual GeneratedPropertyMember Build(
                 NamedTypeSymbol containingType,
-                GeneratedTypePropertyAccessorSymbol getter,
-                GeneratedTypePropertyAccessorSymbol setter,
+                GeneratedProperteyAccessor getter,
+                GeneratedProperteyAccessor setter,
                 FieldSymbol backingField
                 )
             {
@@ -53,8 +50,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal GeneratedPropertyMemberDescriptor PropDescriptor { get; }
 
             #region Implementation
-
-            internal override int? MemberIndexOpt => _memberIndex;
 
             // Parent namespace / type
             public override Symbol ContainingSymbol
@@ -84,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 => PropDescriptor.IsOverride;
 
             internal sealed override bool IsExplicitInterfaceImplementation
-                => PropDescriptor.IsExplicitInterfaceImplementation;
+                => PropDescriptor.ExplicitInterfaceMember != null;
 
             public sealed override bool IsExtern
                 => PropDescriptor.IsExtern;
@@ -102,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Explicit interface
             public override ImmutableArray<PropertySymbol> ExplicitInterfaceImplementations
-                => ImmutableArray<PropertySymbol>.Empty;
+                => (PropDescriptor.ExplicitInterfaceMember as PropertySymbol) != null ? ImmutableArray.Create(PropDescriptor.ExplicitInterfaceMember as PropertySymbol) : ImmutableArray<PropertySymbol>.Empty;
 
             // Syntax declaration
             public override ImmutableArray<Location> Locations
@@ -160,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 }
 
-                var other = obj as GeneratedTypePropertySymbol;
+                var other = obj as GeneratedPropertyMember;
                 if ((object)other == null)
                 {
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbol.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedTypePropertySymbol : PropertySymbol
+        {
+            private NamedTypeSymbol _containingType;
+            private int _memberIndex;
+
+            private GeneratedTypePropertyAccessorSymbol _getter;
+            private GeneratedTypePropertyAccessorSymbol _setter;
+            private FieldSymbol _backingField;
+
+            internal GeneratedTypePropertySymbol(
+                GeneratedPropertyMemberDescriptor descriptor,
+                int index
+                )
+            {
+                PropDescriptor = descriptor;
+                _memberIndex = index;
+            }
+
+            public virtual GeneratedTypePropertySymbol Build(
+                NamedTypeSymbol containingType,
+                GeneratedTypePropertyAccessorSymbol getter,
+                GeneratedTypePropertyAccessorSymbol setter,
+                FieldSymbol backingField
+                )
+            {
+                _containingType = containingType;
+
+                _getter = getter;
+                _setter = setter;
+                _backingField = backingField;
+
+                return this;
+            }
+
+            internal GeneratedPropertyMemberDescriptor PropDescriptor { get; }
+
+            #region Implementation
+
+            internal override int? MemberIndexOpt => _memberIndex;
+
+            // Parent namespace / type
+            public override Symbol ContainingSymbol
+                => _containingType;
+
+            public override NamedTypeSymbol ContainingType
+                => _containingType;
+
+            // Visibility
+            public override Accessibility DeclaredAccessibility
+                => PropDescriptor.Accessibility ?? Accessibility.Internal;
+
+            // Modifiers
+            public override bool IsStatic
+                => PropDescriptor.IsStatic;
+
+            public override bool IsAbstract
+                => PropDescriptor.IsAbstract;
+
+            public override bool IsSealed
+                => PropDescriptor.IsSealed;
+
+            public sealed override bool IsVirtual
+                => PropDescriptor.IsVirtual;
+
+            public override bool IsOverride
+                => PropDescriptor.IsOverride;
+
+            internal sealed override bool IsExplicitInterfaceImplementation
+                => PropDescriptor.IsExplicitInterfaceImplementation;
+
+            public sealed override bool IsExtern
+                => false;
+
+            // Type
+            public override TypeWithAnnotations TypeWithAnnotations
+                => PropDescriptor.Type;
+
+            // Name
+            public sealed override string Name
+                => PropDescriptor.Name;
+
+            internal override bool HasSpecialName
+                => false;
+
+            // Explicit interface
+            public override ImmutableArray<PropertySymbol> ExplicitInterfaceImplementations
+                => ImmutableArray<PropertySymbol>.Empty;
+
+            // Syntax declaration
+            public override ImmutableArray<Location> Locations
+                => PropDescriptor.Locations ?? ImmutableArray<Location>.Empty;
+
+            public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+                => PropDescriptor.DeclaringSyntaxReferences ?? ImmutableArray<SyntaxReference>.Empty;
+
+            // Getter & Setter
+            public FieldSymbol BackingField
+                => _backingField;
+
+            public override MethodSymbol SetMethod
+                => _setter;
+
+            public override MethodSymbol GetMethod
+                => _getter;
+
+            #endregion
+
+            #region Default overrides
+
+            public override RefKind RefKind
+                => RefKind.None;
+
+            public override bool IsImplicitlyDeclared
+                => true;
+
+            public override bool IsIndexer
+                => false;
+
+            internal sealed override ObsoleteAttributeData ObsoleteAttributeData
+                => null;
+
+            public override ImmutableArray<ParameterSymbol> Parameters
+                => ImmutableArray<ParameterSymbol>.Empty;
+
+            public override ImmutableArray<CustomModifier> RefCustomModifiers
+                => ImmutableArray<CustomModifier>.Empty;
+
+            internal override Microsoft.Cci.CallingConvention CallingConvention
+                => Microsoft.Cci.CallingConvention.HasThis;
+
+            internal override bool MustCallMethodsDirectly
+                => false;
+
+            public override bool Equals(Symbol obj, TypeCompareKind compareKind)
+            {
+                if (obj == null)
+                {
+                    return false;
+                }
+                else if (ReferenceEquals(this, obj))
+                {
+                    return true;
+                }
+
+                var other = obj as GeneratedTypePropertySymbol;
+                if ((object)other == null)
+                {
+                    return false;
+                }
+
+                //  consider properties the same is the owning types are the same and 
+                //  the names are equal
+                return ((object)other != null) && other.Name == this.Name
+                    && other.ContainingType.Equals(this.ContainingType, compareKind);
+            }
+
+            public override int GetHashCode()
+            {
+                return Hash.Combine(this.ContainingType.GetHashCode(), this.Name.GetHashCode());
+            }
+            #endregion
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbolAccessors.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbolAccessors.cs
@@ -126,20 +126,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public GeneratedTypePropertySymbol PropertySymbol { get; protected set; }
 
-            internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
-                => Descriptor.IsInterfaceImplementation;
-
-            public override bool IsVirtual
-                => Descriptor.IsVirtual;
-
             public override MethodKind MethodKind
                 => _methodKind;
 
+            internal override bool HasSpecialName
+                => true;
+
             public override bool ReturnsVoid
                 => MethodKind == MethodKind.PropertySet;
-
-            public override RefKind RefKind
-                => RefKind.None;
 
             public override TypeWithAnnotations ReturnTypeWithAnnotations
                 => Descriptor.Type;
@@ -149,21 +143,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override Symbol AssociatedSymbol
                 => PropertySymbol;
-
-            public override ImmutableArray<Location> Locations
-                => Descriptor.Locations ?? ImmutableArray<Location>.Empty;
-
-            public override bool IsOverride
-                => Descriptor.IsOverride;
-
-            internal sealed override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false)
-                => Descriptor.IsVirtual;
-
-            internal override bool IsMetadataFinal
-                => Descriptor.IsFinal;
-
-            internal override bool HasSpecialName
-                => true;
 
             internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbolAccessors.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.PropertySymbolAccessors.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedTypePropertyGetAccessorSymbol : GeneratedTypePropertyAccessorSymbol
+        {
+            internal GeneratedTypePropertyGetAccessorSymbol(GeneratedPropertyMemberDescriptor propDescriptor)
+                : base(propDescriptor, MethodKind.PropertyGet)
+            {
+            }
+        }
+
+        internal class GeneratedTypePropertySetAccessorSymbol : GeneratedTypePropertyAccessorSymbol
+        {
+            internal GeneratedTypePropertySetAccessorSymbol(
+                GeneratedPropertyMemberDescriptor propDescriptor)
+                : base(propDescriptor, MethodKind.PropertySet)
+            {
+            }
+
+            public GeneratedParameterSymbol ValueParameter { get; protected set; }
+
+            public override GeneratedTypePropertyAccessorSymbol Build(
+                NamedTypeSymbol containingType,
+                GeneratedTypePropertySymbol property,
+                Func<SyntheticBoundNodeFactory, BoundStatement> bodyGenerator
+                )
+            {
+                base.Build(
+                    containingType,
+                    property,
+                    bodyGenerator
+                );
+
+                // build the "value" parameter for the setter
+                var pd = new GeneratedParameterDescriptor()
+                {
+                    Name = "value",
+                    Type = ReturnTypeWithAnnotations
+                };
+                ValueParameter = new GeneratedParameterSymbol(pd, 0);
+                ValueParameter.Build(this);
+
+                // add the paramter
+                _parameters = ImmutableArray.Create<ParameterSymbol>(ValueParameter);
+
+                // set void type for the return type
+                Descriptor.Type = TypeWithAnnotations.Create(((GeneratedTypeSymbol)this.ContainingSymbol).Manager.System_Void);
+
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Represents a getter for generated type property.
+        /// </summary>
+        internal class GeneratedTypePropertyAccessorSymbol : SynthesizedMethodBase
+        {
+            private MethodKind _methodKind;
+            private Func<SyntheticBoundNodeFactory, BoundStatement> _bodyGenerator;
+            protected ImmutableArray<ParameterSymbol> _parameters;
+
+            internal GeneratedTypePropertyAccessorSymbol(
+                GeneratedPropertyMemberDescriptor propDescriptor,
+                MethodKind methodKind
+                )
+                // winmdobj output only effects setters, so we can always set this to false
+                : base(GetDescriptor(propDescriptor, methodKind))
+            {
+                _methodKind = methodKind;
+                _parameters = ImmutableArray<ParameterSymbol>.Empty;
+            }
+
+            protected static GeneratedMethodMemberDescriptor GetDescriptor(GeneratedPropertyMemberDescriptor propDescriptor, MethodKind methodKind)
+            {
+                var d = new GeneratedMethodMemberDescriptor();
+                var isGetter = methodKind == MethodKind.PropertyGet;
+                d.Name = SourcePropertyAccessorSymbol.GetAccessorName(propDescriptor.Name, getNotSet: isGetter, isWinMdOutput: false);
+                d.Type = propDescriptor.Type;
+                d.Accessibility = propDescriptor.Accessibility;
+                d.Locations = propDescriptor.Locations;
+                d.DeclaringSyntaxReferences = propDescriptor.DeclaringSyntaxReferences;
+
+                // some default values that are needed when implementing an interface
+                d.Interface = propDescriptor.Interface;
+                d.IsInterfaceImplementation = propDescriptor.IsInterfaceImplementation;
+                d.IsVirtual = propDescriptor.IsVirtual;
+                d.IsOverride = propDescriptor.IsOverride;
+                d.IsFinal = propDescriptor.IsFinal;
+
+                if (d.IsInterfaceImplementation)
+                {
+                    d.IsFinal = true;
+                    d.IsVirtual = true;
+                }
+
+                return d;
+            }
+
+            public virtual GeneratedTypePropertyAccessorSymbol Build(
+                NamedTypeSymbol containingType,
+                GeneratedTypePropertySymbol property,
+                Func<SyntheticBoundNodeFactory, BoundStatement> bodyGenerator
+                )
+            {
+                _containingType = containingType;
+                PropertySymbol = property;
+
+                _bodyGenerator = bodyGenerator;
+                return this;
+            }
+
+            public GeneratedTypePropertySymbol PropertySymbol { get; protected set; }
+
+            internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+                => Descriptor.IsInterfaceImplementation;
+
+            public override bool IsVirtual
+                => Descriptor.IsVirtual;
+
+            public override MethodKind MethodKind
+                => _methodKind;
+
+            public override bool ReturnsVoid
+                => MethodKind == MethodKind.PropertySet;
+
+            public override RefKind RefKind
+                => RefKind.None;
+
+            public override TypeWithAnnotations ReturnTypeWithAnnotations
+                => Descriptor.Type;
+
+            public override ImmutableArray<ParameterSymbol> Parameters
+                => _parameters;
+
+            public override Symbol AssociatedSymbol
+                => PropertySymbol;
+
+            public override ImmutableArray<Location> Locations
+                => Descriptor.Locations ?? ImmutableArray<Location>.Empty;
+
+            public override bool IsOverride
+                => Descriptor.IsOverride;
+
+            internal sealed override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false)
+                => Descriptor.IsVirtual;
+
+            internal override bool IsMetadataFinal
+                => Descriptor.IsFinal;
+
+            internal override bool HasSpecialName
+                => true;
+
+            internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+            {
+                // Do not call base.AddSynthesizedAttributes.
+                // Dev11 does not emit DebuggerHiddenAttribute in property accessors
+            }
+
+            internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
+            {
+                var factory = CreateBoundNodeFactory(compilationState, diagnostics);
+                var body = _bodyGenerator(factory);
+                factory.CloseMethod(body);
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/SynthesizedSymobls/GeneratedType.TypeParameterSymbol.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal partial class GeneratedTypesManager
+    {
+        internal class GeneratedTypeParameterSymbol : TypeParameterSymbol
+        {
+            private int _ordinal;
+            private Symbol _containingSymbol;
+            private TypeParameterKind _typeParameterKind;
+
+            internal GeneratedTypeParameterSymbol(GeneratedTypeParameterDescriptor descriptor, int ordinal)
+            {
+                Descriptor = descriptor;
+                _ordinal = ordinal;
+            }
+
+            protected GeneratedTypeParameterDescriptor Descriptor { get; }
+
+            public GeneratedTypeParameterSymbol Build(Symbol containingSymbol)
+            {
+                _containingSymbol = containingSymbol;
+
+                switch (containingSymbol.Kind)
+                {
+                    case SymbolKind.Method:
+                        _typeParameterKind = TypeParameterKind.Method;
+                        break;
+                    case SymbolKind.NamedType:
+                        _typeParameterKind = TypeParameterKind.Type;
+                        break;
+                    default:
+                        break;
+                }
+
+                return this;
+            }
+
+            public override TypeParameterKind TypeParameterKind => _typeParameterKind;
+
+            public override string Name => Descriptor.Name;
+
+            public override int Ordinal => _ordinal;
+
+            public override bool HasConstructorConstraint => Descriptor.HasConstructorConstraint;
+            public override bool HasReferenceTypeConstraint => Descriptor.HasReferenceTypeConstraint;
+            public override bool HasNotNullConstraint => Descriptor.HasNotNullConstraint;
+            public override bool HasValueTypeConstraint => Descriptor.HasValueTypeConstraint;
+            public override bool HasUnmanagedTypeConstraint => Descriptor.HasUnmanagedTypeConstraint;
+
+            public override VarianceKind Variance => Descriptor.Variance;
+
+            public override Symbol ContainingSymbol => _containingSymbol;
+
+            public override ImmutableArray<Location> Locations
+                => Descriptor.Locations ?? ImmutableArray<Location>.Empty;
+
+            public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+                => Descriptor.DeclaringSyntaxReferences ?? ImmutableArray<SyntaxReference>.Empty;
+
+            internal override bool? IsNotNullable => null;
+
+            internal override bool? ReferenceTypeConstraintIsNullable => null;
+
+            internal override void EnsureAllConstraintsAreResolved()
+            {
+            }
+
+            internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress)
+                => Descriptor.ConstraintTypes ?? ImmutableArray<TypeWithAnnotations>.Empty;
+
+            internal override TypeSymbol GetDeducedBaseType(ConsList<TypeParameterSymbol> inProgress)
+                => null;
+
+            internal override NamedTypeSymbol GetEffectiveBaseClass(ConsList<TypeParameterSymbol> inProgress)
+                => null;
+
+            internal override ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress)
+                => ImmutableArray<NamedTypeSymbol>.Empty;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Equality options for parameter types and return types (if return is considered).
         private readonly TypeCompareKind _typeComparison;
 
-        private MemberSignatureComparer(
+        internal MemberSignatureComparer(
             bool considerName,
             bool considerExplicitlyImplementedInterfaces,
             bool considerReturnType,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3424,7 +3424,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We won't insert a parameterless constructor for a struct if there already is one.
             // We don't expect anything to be emitted, but it should be in the symbol table.
             if ((!hasParameterlessInstanceConstructor && this.IsStructType()) ||
-                (!hasInstanceConstructor && !this.IsStatic))
+                (!hasInstanceConstructor && !this.IsStatic && !this.IsInterfaceType()))
             {
                 members.Add((this.TypeKind == TypeKind.Submission) ?
                     new SynthesizedSubmissionConstructor(this, diagnostics) :

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2451,12 +2451,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case TypeKind.Struct:
                     CheckForStructBadInitializers(builder, diagnostics);
                     CheckForStructDefaultConstructors(builder.NonTypeNonIndexerMembers, isEnum: false, diagnostics: diagnostics);
-                    AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics);
+                    AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics, TypeKind);
                     break;
 
                 case TypeKind.Enum:
                     CheckForStructDefaultConstructors(builder.NonTypeNonIndexerMembers, isEnum: true, diagnostics: diagnostics);
-                    AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics);
+                    AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics, TypeKind);
                     break;
 
                 case TypeKind.Class:
@@ -2464,7 +2464,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case TypeKind.Submission:
                     // No additional checking required.
                     AddSynthesizedRecordMembersIfNecessary(builder, diagnostics);
-                    AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics);
+                    AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics, TypeKind);
                     break;
 
                 default:
@@ -2910,8 +2910,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     switch (meth.MethodKind)
                     {
                         case MethodKind.Constructor:
-                            diagnostics.Add(ErrorCode.ERR_InterfacesCantContainConstructors, member.Locations[0]);
-                            break;
+                            {
+                                if (!(member is SynthesizedInstanceMethodSymbol))
+                                    diagnostics.Add(ErrorCode.ERR_InterfacesCantContainConstructors, member.Locations[0]);
+                                break;
+                            }
                         case MethodKind.Conversion:
                             diagnostics.Add(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, member.Locations[0]);
                             break;
@@ -3378,7 +3381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private void AddSynthesizedConstructorsIfNecessary(ArrayBuilder<Symbol> members, ArrayBuilder<ArrayBuilder<FieldOrPropertyInitializer.Builder>> staticInitializers, DiagnosticBag diagnostics)
+        private void AddSynthesizedConstructorsIfNecessary(ArrayBuilder<Symbol> members, ArrayBuilder<ArrayBuilder<FieldOrPropertyInitializer.Builder>> staticInitializers, DiagnosticBag diagnostics, TypeKind typeKind)
         {
             //we're not calling the helpers on NamedTypeSymbol base, because those call
             //GetMembers and we're inside a GetMembers call ourselves (i.e. stack overflow)
@@ -3421,7 +3424,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We won't insert a parameterless constructor for a struct if there already is one.
             // We don't expect anything to be emitted, but it should be in the symbol table.
             if ((!hasParameterlessInstanceConstructor && this.IsStructType()) ||
-                (!hasInstanceConstructor && !this.IsStatic && !this.IsInterface))
+                (!hasInstanceConstructor && !this.IsStatic))
             {
                 members.Add((this.TypeKind == TypeKind.Submission) ?
                     new SynthesizedSubmissionConstructor(this, diagnostics) :

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override Accessibility DeclaredAccessibility
         {
-            get { return ContainingType.IsAbstract ? Accessibility.Protected : Accessibility.Public; }
+            get { return (ContainingType.IsAbstract && !ContainingType.IsInterface) ? Accessibility.Protected : Accessibility.Public; }
         }
 
         internal override bool IsMetadataFinal

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
@@ -8,7 +8,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal enum TypeAnnotationKind
     {
-        ThisParamType
+        ThisParamType,
+        OriginalType
     }
 
     internal partial class TypeSymbol

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/CSharpSyntaxNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -116,6 +117,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public SyntaxToken GetFirstToken()
         {
             return (SyntaxToken)this.GetFirstTerminal();
+        }
+
+        public SyntaxToken GetFirstToken(Func<SyntaxToken, bool> predicate)
+        {
+            return (SyntaxToken)this.GetFirstTerminal<SyntaxToken>(predicate);
         }
 
         public SyntaxToken GetFirstNonZeroWidthToken()

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -432,5 +432,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             return result;
         }
+
+        public static AccessorListSyntax FakeAccessorList(bool getter = true, bool setter = true)
+        {
+            SyntaxList<AccessorDeclarationSyntax> accessors = null;
+
+            if (getter && setter)
+            {
+                accessors = SyntaxFactory.List(
+                    SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, default, default, SyntaxFactory.FakeToken(SyntaxKind.GetKeyword), null, null, SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken)),
+                    SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, default, default, SyntaxFactory.FakeToken(SyntaxKind.SetKeyword), null, null, SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken))
+                );
+            }
+            else if (getter)
+            {
+                accessors = SyntaxFactory.List(
+                    SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, default, default, SyntaxFactory.FakeToken(SyntaxKind.GetKeyword), null, null, SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken))
+                );
+            }
+            else if(setter)
+            {
+                accessors = SyntaxFactory.List(
+                    SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, default, default, SyntaxFactory.FakeToken(SyntaxKind.SetKeyword), null, null, SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken))
+                );
+            }
+
+            return AccessorList(FakeToken(SyntaxKind.OpenBraceToken), accessors, FakeToken(SyntaxKind.CloseBraceToken));
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -572,6 +572,13 @@ namespace Microsoft.CodeAnalysis.Emit
                 yield return typeDef;
             }
 
+            foreach (var typeDef in GetGeneratedTypeDefinitions(context))
+            {
+                AddTopLevelType(names, typeDef);
+                VisitTopLevelType(typeReferenceIndexer, typeDef);
+                yield return typeDef;
+            }
+
             foreach (var typeDef in GetTopLevelTypeDefinitionsCore(context))
             {
                 AddTopLevelType(names, typeDef);
@@ -602,6 +609,8 @@ namespace Microsoft.CodeAnalysis.Emit
                 _namesOfTopLevelTypes = names;
             }
         }
+
+        public virtual IEnumerable<Cci.INamespaceTypeDefinition> GetGeneratedTypeDefinitions(EmitContext context) => Enumerable.Empty<Cci.INamespaceTypeDefinition>();
 
         public override IEnumerable<Cci.INamespaceTypeDefinition> GetAdditionalTopLevelTypeDefinitions(EmitContext context)
             => GetAdditionalTopLevelTypes(context.Diagnostics);

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -773,6 +773,40 @@ namespace Microsoft.CodeAnalysis
             return this;
         }
 
+        internal T? GetFirstTerminal<T>(Func<T, bool> predicate)
+            where T : GreenNode
+        {
+            if (this is T thisT)
+            {
+                if (predicate(thisT))
+                    return thisT;
+            }
+
+            for (int i = 0, n = SlotCount; i < n; i++)
+            {
+                var child = GetSlot(i);
+                if (child is T childT)
+                {
+                    if (predicate(childT))
+                        return childT;
+                }
+            }
+
+            for (int i = 0, n = SlotCount; i < n; i++)
+            {
+                var child = GetSlot(i);
+                if (child != null)
+                {
+                    // try with the sub children
+                    var firstSubTerminal = child.GetFirstTerminal(predicate);
+                    if (firstSubTerminal != null)
+                        return firstSubTerminal;
+                }
+            }
+
+            return null;
+        }
+
         internal GreenNode? GetFirstTerminal()
         {
             GreenNode? node = this;


### PR DESCRIPTION
Adds instantiation of interface types by auto-generating a default implementation for each interface that is used in a "new IMyInterface()" statement - works the same way as if one would instantiate a normal class.

This enables "quick implement" / composition of "option classes" with the purpose of composing many different options into an "arg structure".

Methods are implemented with a "dummy method" returning the "default value" - async / task methods generate valid Task results.

Enables syntax like:
```
// interface declaration
interface MyInterface {
  name string
  age int
  getDetails() string
}

// usage
i := new MyInterface()
i := new MyInterface {
  name = "george"
  age = 35
}
```