### PR TITLE
Updates lambda binding with automatic conversion to async lambda

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override bool HasSignature { get { return true; } }
             public override bool HasExplicitlyTypedParameterList { get { return false; } }
             public override int ParameterCount { get { return _parameters.Length; } }
-            public override bool IsAsync { get { return false; } }
+            public override bool IsAsync { get { return false; } set { } }
             public override bool IsStatic => false;
             public override RefKind RefKind(int index) { return Microsoft.CodeAnalysis.RefKind.None; }
             public override MessageID MessageID { get { return MessageID.IDS_FeatureQueryExpression; } } // TODO: what is the correct ID here?

--- a/src/Compilers/CSharp/Portable/Symbols/Source/Helpers/CodeBlockExitPathsFinder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/Helpers/CodeBlockExitPathsFinder.cs
@@ -26,6 +26,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Source.Helpers
             visitor.Visit(node);
         }
 
+        public static bool HasAnyTaskReturnTypes(BoundNode node, CSharpCompilation compilation)
+        {
+            var exitPaths = ArrayBuilder<(BoundNode, TypeWithAnnotations?)>.GetInstance();
+            try
+            {
+                var visitor = new CodeBlockExitPathsFinder(exitPaths);
+                visitor.Visit(node);
+                return exitPaths.Any(p => p.Item2.HasValue && p.Item2.Value.Type?.IsAsyncTaskType(compilation) == true);
+            }
+            finally
+            {
+                exitPaths.Free();
+            }
+        }
+
         public override BoundNode Visit(BoundNode node)
         {
             if (!(node is BoundExpression))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private RefKind _refKind;
         private TypeWithAnnotations _returnType;
         private readonly bool _isSynthesized;
-        private readonly bool _isAsync;
+        internal bool _isAsync;
         private readonly bool _isStatic;
         private readonly int _thisParamIndex;
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1908,6 +1908,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 !returnType.IsIAsyncEnumeratorType(declaringCompilation);
         }
 
+        public static bool IsAsyncTaskType(this TypeSymbol type, CSharpCompilation declaringCompilation)
+        {
+            // Note: we're passing the return type explicitly (rather than using `method.ReturnType`) to avoid cycles
+            return type.IsNonGenericTaskType(declaringCompilation) ||
+                type.IsGenericTaskType(declaringCompilation) ||
+                type.IsIAsyncEnumerableType(declaringCompilation) ||
+                type.IsIAsyncEnumeratorType(declaringCompilation);
+        }
+
         internal static int TypeToIndex(this TypeSymbol type)
         {
             switch (type.GetSpecialTypeSafe())


### PR DESCRIPTION
Makes lambdas automatically convert to "async" returning implicit Task when expected Task as return type - this allows to code less "aware" where it's async or not - especially useful for simple callback arguments.

Enables syntax like:

```
// helper function that invokes an async lambda
async testMethod(callback async fn()) {
  await callback()
}

// using this we can declare an implicit async lambda
testMethod(callback: {
  // this will run async without having to declare "async" or returning a "Task" type
})
```