### PR TITLE
Feature/global functions

### DIFF
--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -32,6 +32,9 @@
     <Compile Include="..\..\..\Workspaces\Core\Portable\Editing\DeclarationModifiers.cs" Link="Editing\DeclarationModifiers.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Update="CodeStyleResources.resx" GenerateSource="true" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -425,7 +425,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        container = ((NamespaceSymbol)containingSymbol).ImplicitType;
+                        var nsSymbol = (NamespaceSymbol)containingSymbol;
+                        container = nsSymbol.GlobalMembersContainerType ?? nsSymbol.ImplicitType;
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -145,8 +145,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal Binder GetFieldInitializerBinder(FieldSymbol fieldSymbol, bool suppressBinderFlagsFieldInitializer = false)
         {
-            Debug.Assert((ContainingMemberOrLambda is TypeSymbol containing && TypeSymbol.Equals(containing, fieldSymbol.ContainingType, TypeCompareKind.ConsiderEverything2)) || //should be the binder for the type
-                    fieldSymbol.ContainingType.IsImplicitClass); //however, we also allow fields in namespaces to help support script scenarios
+            // containing member should either be a type or a namespace
+            var containingType = ContainingMemberOrLambda as TypeSymbol ?? (ContainingMemberOrLambda as NamespaceSymbol)?.GlobalMembersContainerType;
+            Debug.Assert(
+                (TypeSymbol.Equals(containingType, fieldSymbol.ContainingType, TypeCompareKind.ConsiderEverything2)) || //should be the binder for the type
+                fieldSymbol.ContainingType.IsImplicitClass //however, we also allow fields in namespaces to help support script scenarios
+            );
 
             Binder binder = this;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1583,10 +1583,10 @@ symIsHidden:;
         /// Should only be called by <see cref="IsAccessible(Symbol, TypeSymbol, out bool, ref HashSet{DiagnosticInfo}, ConsList{TypeSymbol})"/>,
         /// which will already have checked for <see cref="BinderFlags.IgnoreAccessibility"/>.
         /// </remarks>
-        internal virtual bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved)
+        internal virtual bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved, Binder innerBinder = null)
         {
             // By default, just delegate to containing binder.
-            return Next.IsAccessibleHelper(symbol, accessThroughType, out failedThroughTypeCheck, ref useSiteDiagnostics, basesBeingResolved);
+            return Next.IsAccessibleHelper(symbol, accessThroughType, out failedThroughTypeCheck, ref useSiteDiagnostics, basesBeingResolved, innerBinder);
         }
 
         internal bool IsNonInvocableMember(Symbol symbol)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1216,6 +1216,23 @@ symIsHidden:;
 
         internal static ImmutableArray<Symbol> GetCandidateMembers(NamespaceOrTypeSymbol nsOrType, string name, LookupOptions options, Binder originalBinder)
         {
+            var results = GetCandidateMembers_(nsOrType, name, options, originalBinder);
+
+            if (nsOrType is NamespaceSymbol nsSymbol)
+            {
+                var globalMembersType = nsSymbol.GlobalMembersContainerType;
+                if (!(globalMembersType is null))
+                {
+                    var globalsResults = GetCandidateMembers_(globalMembersType, name, options, originalBinder);
+                    results = results.AddRange(globalsResults);
+                }
+            }
+
+            return results;
+        }
+
+        internal static ImmutableArray<Symbol> GetCandidateMembers_(NamespaceOrTypeSymbol nsOrType, string name, LookupOptions options, Binder originalBinder)
+        {
             if ((options & LookupOptions.NamespacesOrTypesOnly) != 0 && nsOrType is TypeSymbol)
             {
                 return nsOrType.GetTypeMembers(name).Cast<NamedTypeSymbol, Symbol>();
@@ -1235,6 +1252,23 @@ symIsHidden:;
         }
 
         internal static ImmutableArray<Symbol> GetCandidateMembers(NamespaceOrTypeSymbol nsOrType, LookupOptions options, Binder originalBinder)
+        {
+            var results = GetCandidateMembers_(nsOrType, options, originalBinder);
+
+            if (nsOrType is NamespaceSymbol nsSymbol)
+            {
+                var globalMembersType = nsSymbol.GlobalMembersContainerType;
+                if (!(globalMembersType is null))
+                {
+                    var globalsResults = GetCandidateMembers_(globalMembersType, options, originalBinder);
+                    results = results.AddRange(globalsResults);
+                }
+            }
+
+            return results;
+        }
+
+        internal static ImmutableArray<Symbol> GetCandidateMembers_(NamespaceOrTypeSymbol nsOrType, LookupOptions options, Binder originalBinder)
         {
             if ((options & LookupOptions.NamespacesOrTypesOnly) != 0 && nsOrType is TypeSymbol)
             {

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override bool InExecutableBinder => false;
 
-        internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo>? useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved)
+        internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo>? useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved, Binder innerBinder = null)
         {
             failedThroughTypeCheck = false;
             return IsSymbolAccessibleConditional(symbol, Compilation.Assembly, ref useSiteDiagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -4035,7 +4035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // - Then, any parameter whose type is open (i.e. contains a type parameter; see §4.4.2) is elided, along with its corresponding parameter(s).
             // and
             // - The modified parameter list for F is applicable to the modified argument list in terms of section §7.5.3.1
-            if (ignoreOpenTypes && parameterType.ContainsTypeParameter(parameterContainer: (MethodSymbol)candidate))
+            if (ignoreOpenTypes && candidate is MethodSymbol methodCandidate && parameterType.ContainsTypeParameter(parameterContainer: methodCandidate))
             {
                 // defer applicability check to runtime:
                 return Conversion.ImplicitDynamic;

--- a/src/Compilers/CSharp/Portable/Binder/WithClassTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithClassTypeParametersBinder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _namedType = container;
         }
 
-        internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved)
+        internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved, Binder innerBinder = null)
         {
             return this.IsSymbolAccessibleConditional(symbol, _namedType, accessThroughType, out failedThroughTypeCheck, ref useSiteDiagnostics, basesBeingResolved);
         }

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2300,8 +2300,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return container;
             }
 
+            var nsSymbol = (NamespaceSymbol)container;
+
             // another member in a namespace:
-            return ((NamespaceSymbol)container).ImplicitType;
+            return nsSymbol.GlobalMembersContainerType ?? nsSymbol.ImplicitType;
         }
 
         private Symbol GetDeclaredMemberSymbol(CSharpSyntaxNode declarationSyntax)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -380,7 +380,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             _cancellationToken.ThrowIfCancellationRequested();
 
             var concurrent = _compilation.Options.ConcurrentBuild;
-            concurrent = false;
             if (concurrent)
             {
                 Task worker = CompileNamedTypeAsync(symbol);

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 kind: DeclarationKind.Class,
                 name: NamespaceSymbolHelpers.GetNamespaceMembersContainerClassName(nsDecl.Name.ToString().Trim()),
                 arity: 0,
-                modifiers: DeclarationModifiers.Public | DeclarationModifiers.Partial | DeclarationModifiers.Sealed,
+                modifiers: DeclarationModifiers.Public | DeclarationModifiers.Partial | DeclarationModifiers.Static,
                 declFlags: declFlags,
                 syntaxReference: container,
                 nameLocation: new SourceLocation(container),

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -106,10 +106,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var memberNames = GetNonTypeMemberNames(internalMembers, ref declFlags, skipGlobalStatements: acceptSimpleProgram);
                 var container = _syntaxTree.GetReference(node);
 
-                childrenBuilder.Add(CreateImplicitClass(memberNames, container, declFlags));
+                if (node is NamespaceDeclarationSyntax nsDecl)
+                {
+                    childrenBuilder.Add(CreateNamespaceMembersContainerClass(memberNames, nsDecl, container, declFlags));
+                }
+                else
+                {
+                    childrenBuilder.Add(CreateImplicitClass(memberNames, container, declFlags));
+                }
             }
 
             return childrenBuilder.ToImmutableAndFree();
+        }
+
+        private static SingleNamespaceOrTypeDeclaration CreateNamespaceMembersContainerClass(ImmutableHashSet<string> memberNames, NamespaceDeclarationSyntax nsDecl, SyntaxReference container, SingleTypeDeclaration.TypeDeclarationFlags declFlags)
+        {
+            return new SingleTypeDeclaration(
+                kind: DeclarationKind.Class,
+                name: NamespaceSymbolHelpers.GetNamespaceMembersContainerClassName(nsDecl.Name.ToString().Trim()),
+                arity: 0,
+                modifiers: DeclarationModifiers.Public | DeclarationModifiers.Partial | DeclarationModifiers.Sealed,
+                declFlags: declFlags,
+                syntaxReference: container,
+                nameLocation: new SourceLocation(container),
+                memberNames: memberNames,
+                children: ImmutableArray<SingleTypeDeclaration>.Empty,
+                diagnostics: ImmutableArray<Diagnostic>.Empty);
         }
 
         private static SingleNamespaceOrTypeDeclaration CreateImplicitClass(ImmutableHashSet<string> memberNames, SyntaxReference container, SingleTypeDeclaration.TypeDeclarationFlags declFlags)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             internal override Symbol? ContainingMemberOrLambda { get { return _factory.CurrentFunction; } }
-            internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo>? useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved)
+            internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo>? useSiteDiagnostics, ConsList<TypeSymbol> basesBeingResolved, Binder innerBinder = null)
             {
                 return AccessCheck.IsSymbolAccessible(symbol, _factory.CurrentType, accessThroughType, out failedThroughTypeCheck, ref useSiteDiagnostics, basesBeingResolved);
             }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13033,15 +13033,40 @@ tryAgain:
                         //
                         // It's far more likely the member access expression is simply incomplete and
                         // there is a new declaration on the next line.
-                        if (this.CurrentToken.TrailingTrivia.Any((int)SyntaxKind.EndOfLineTrivia) &&
-                            this.PeekToken(1).Kind == SyntaxKind.IdentifierToken &&
-                            this.PeekToken(2).ContextualKind == SyntaxKind.IdentifierToken)
+
+                        // in order for it to be a member access it must be either on same line or on a newline with indentation! compared to the current
+
+                        var isAtEndOfLine = this.CurrentToken.TrailingTrivia.Any((int)SyntaxKind.EndOfLineTrivia);
+                        if (isAtEndOfLine)
                         {
-                            expr = _syntaxFactory.MemberAccessExpression(
+                            // check if next token is indented and a valid member access token
+                            var isBadExpression = false;
+                            var nextToken = this.PeekToken(1);
+
+                            // next token may not be a member modifier
+                            if (!IsTrueIdentifier(nextToken))
+                                isBadExpression = true;
+
+                            if (!isBadExpression && SyntaxFacts.IsMemberModifier(nextToken.Kind))
+                                isBadExpression = true;
+
+                            if (!isBadExpression && SyntaxFacts.IsAccessibilityModifier(nextToken.Kind))
+                                isBadExpression = true;
+
+                            // next token must be indented
+                            if (!isBadExpression)
+                            {
+                                if (!IsTokenLineIndentedRelativeToCurrent(1))
+                                    isBadExpression = true;
+                            }
+
+                            if (isBadExpression)
+                            {
+                                expr = _syntaxFactory.MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression, expr, this.EatToken(),
                                 this.AddError(this.CreateMissingIdentifierName(), ErrorCode.ERR_IdentifierExpected));
-
-                            return expr;
+                                return expr;
+                            }
                         }
 
                         expr = _syntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expr, this.EatToken(), this.ParseSimpleName(NameOptions.InExpression));

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -530,27 +530,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                         case SyntaxKind.UsingKeyword:
                         case SyntaxKind.ImportKeyword:
-                            if (isGlobal && (this.PeekToken(1).Kind == SyntaxKind.OpenParenToken || (!IsScript && IsPossibleTopLevelUsingLocalDeclarationStatement())))
+                            if (CurrentKind == SyntaxKind.UsingKeyword)
                             {
-                                // Top-level using statement or using local declaration
-                                goto default;
+                                if (this.PeekToken(1).Kind == SyntaxKind.OpenParenToken || (!IsScript && IsPossibleTopLevelUsingLocalDeclarationStatement()))
+                                {
+                                    goto default;
+                                }
+                            }
+
+                            // incomplete members must be processed before we add any nodes to the body:
+                            ReduceIncompleteMembers(ref pendingIncompleteMembers, ref openBrace, ref body, ref initialBadNodes);
+
+                            var @using = this.ParseUsingDirective();
+                            if (seen > NamespaceParts.Usings)
+                            {
+                                @using = this.AddError(@using, ErrorCode.ERR_UsingAfterElements);
+                                this.AddSkippedNamespaceText(ref openBrace, ref body, ref initialBadNodes, @using);
                             }
                             else
                             {
-                                // incomplete members must be processed before we add any nodes to the body:
-                                ReduceIncompleteMembers(ref pendingIncompleteMembers, ref openBrace, ref body, ref initialBadNodes);
-
-                                var @using = this.ParseUsingDirective();
-                                if (seen > NamespaceParts.Usings)
-                                {
-                                    @using = this.AddError(@using, ErrorCode.ERR_UsingAfterElements);
-                                    this.AddSkippedNamespaceText(ref openBrace, ref body, ref initialBadNodes, @using);
-                                }
-                                else
-                                {
-                                    body.Usings.Add(@using);
-                                    seen = NamespaceParts.Usings;
-                                }
+                                body.Usings.Add(@using);
+                                seen = NamespaceParts.Usings;
                             }
 
                             reportUnexpectedToken = true;
@@ -581,7 +581,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             goto default;
 
                         default:
-                            var memberOrStatement = isGlobal ? this.ParseMemberDeclarationOrStatement(parentKind) : this.ParseMemberDeclaration(parentKind);
+                            var memberOrStatement = this.ParseMemberDeclaration(parentKind);
                             if (memberOrStatement == null)
                             {
                                 // incomplete members must be processed before we add any nodes to the body:
@@ -638,11 +638,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         else if (seen == NamespaceParts.TypesAndNamespaces)
                         {
                             seen = NamespaceParts.TopLevelStatementsAfterTypesAndNamespaces;
-
-                            if (!IsScript)
-                            {
-                                memberOrStatement = this.AddError(memberOrStatement, ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType);
-                            }
                         }
 
                         break;
@@ -680,7 +675,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
 
             _checkedTopLevelStatementsFeatureAvailability = true;
-            return CheckFeatureAvailability(globalStatementSyntax, MessageID.IDS_TopLevelStatements);
+            return globalStatementSyntax;
         }
 
         private static void AddIncompleteMembers(ref SyntaxListBuilder<MemberDeclarationSyntax> incompleteMembers, ref NamespaceBodyBuilder body)
@@ -2199,7 +2194,6 @@ tryAgain:
         {
             // "top-level" expressions and statements should never occur inside an asynchronous context
             Debug.Assert(!IsInAsync);
-            Debug.Assert(parentKind == SyntaxKind.CompilationUnit);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -2211,6 +2205,8 @@ tryAgain:
                     return (MemberDeclarationSyntax)this.EatNode();
                 }
             }
+
+            var isNamespaceStatement = parentKind == SyntaxKind.NamespaceDeclaration;
 
             var saveTermState = _termState;
 
@@ -2856,7 +2852,7 @@ parse_member_name:;
                 // Check for constructor form
                 if ((CurrentKind == SyntaxKind.IdentifierToken || CurrentKind == SyntaxKind.ThisKeyword) && this.PeekToken(1).Kind == SyntaxKind.OpenParenToken)
                 {
-                    if (parentName == null || parentName.Text == this.CurrentToken.Text || CurrentKind == SyntaxKind.ThisKeyword)
+                    if (parentName?.Text == this.CurrentToken.Text || CurrentKind == SyntaxKind.ThisKeyword)
                     {
                         return this.ParseConstructorDeclaration(attributes, modifiers);
                     }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitField(IFieldSymbol symbol)
         {
+            var isGlobalNamespaceMember = NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(symbol.ContainingType?.Name ?? "");
+
             AddAccessibilityIfRequired(symbol);
             AddMemberModifiersIfRequired(symbol);
             AddFieldModifiersIfRequired(symbol);
@@ -41,8 +43,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeContainingType) &&
                 IncludeNamedType(symbol.ContainingType))
             {
-                symbol.ContainingType.Accept(this.NotFirstVisitor);
-                AddPunctuation(SyntaxKind.DotToken);
+                if (isGlobalNamespaceMember)
+                {
+                    var containingNamespace = symbol.ContainingType?.ContainingNamespace;
+                    if (containingNamespace != null && !containingNamespace.IsGlobalNamespace)
+                    {
+                        containingNamespace.Accept(this.NotFirstVisitor);
+                        AddPunctuation(SyntaxKind.DotToken);
+                    }
+                }
+                else
+                {
+                    symbol.ContainingType.Accept(this.NotFirstVisitor);
+                    AddPunctuation(SyntaxKind.DotToken);
+                }
             }
 
             if (symbol.ContainingType.TypeKind == TypeKind.Enum)
@@ -119,6 +133,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitProperty(IPropertySymbol symbol)
         {
+            var isGlobalNamespaceMember = NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(symbol.ContainingType?.Name ?? "");
+
             AddAccessibilityIfRequired(symbol);
             AddMemberModifiersIfRequired(symbol);
 
@@ -149,8 +165,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeContainingType) &&
                 IncludeNamedType(symbol.ContainingType))
             {
-                symbol.ContainingType.Accept(this.NotFirstVisitor);
-                AddPunctuation(SyntaxKind.DotToken);
+                if (isGlobalNamespaceMember)
+                {
+                    var containingNamespace = symbol.ContainingType?.ContainingNamespace;
+                    if (containingNamespace != null && !containingNamespace.IsGlobalNamespace)
+                    {
+                        containingNamespace.Accept(this.NotFirstVisitor);
+                        AddPunctuation(SyntaxKind.DotToken);
+                    }
+                }
+                else
+                {
+                    symbol.ContainingType.Accept(this.NotFirstVisitor);
+                    AddPunctuation(SyntaxKind.DotToken);
+                }
             }
 
             AddPropertyNameAndParameters(symbol);
@@ -255,6 +283,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitMethod(IMethodSymbol symbol)
         {
+            var isGlobalNamespaceMember = NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(symbol.ContainingType?.Name ?? "");
+
             if (symbol.MethodKind == MethodKind.AnonymousFunction)
             {
                 // TODO(cyrusn): Why is this a literal?  Why don't we give the appropriate signature
@@ -416,7 +446,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (includeType)
                     {
-                        if (NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(containingType?.Name ?? ""))
+                        if (isGlobalNamespaceMember)
                         {
                             var containingNamespace = containingType?.ContainingNamespace;
                             if (containingNamespace != null && !containingNamespace.IsGlobalNamespace)
@@ -733,6 +763,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             INamedTypeSymbol containingType = symbol.ContainingType;
 
+            var isGlobalNamespaceMember = NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(containingType?.Name ?? "");
+
             // all members (that end up here) must have a containing type or a containing symbol should be a TypeSymbol.
             Debug.Assert(containingType != null || (symbol.ContainingSymbol is ITypeSymbol));
 
@@ -741,7 +773,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                  (containingType.TypeKind != TypeKind.Interface && !IsEnumMember(symbol) && !IsLocalFunction(symbol))))
             {
                 var isConst = symbol is IFieldSymbol && ((IFieldSymbol)symbol).IsConst;
-                if (symbol.IsStatic && !isConst)
+                if (symbol.IsStatic && !isConst && !isGlobalNamespaceMember)
                 {
                     AddKeyword(SyntaxKind.StaticKeyword);
                     AddSpace();

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -416,8 +416,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (includeType)
                     {
-                        containingType.Accept(this.NotFirstVisitor);
-                        AddPunctuation(SyntaxKind.DotToken);
+                        if (NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(containingType?.Name ?? ""))
+                        {
+                            var containingNamespace = containingType?.ContainingNamespace;
+                            if (containingNamespace != null && !containingNamespace.IsGlobalNamespace)
+                            {
+                                containingNamespace.Accept(this.NotFirstVisitor);
+                                AddPunctuation(SyntaxKind.DotToken);
+                            }
+                        }
+                        else
+                        {
+                            containingType.Accept(this.NotFirstVisitor);
+                            AddPunctuation(SyntaxKind.DotToken);
+                        }
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -234,7 +234,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                var name = NamespaceSymbolHelpers.GetNamespaceMembersContainerClassName(this.Name.ToString().Trim());
+                var fullName = (this.QualifiedName ?? this.Name).Trim();
+                var name = NamespaceSymbolHelpers.GetNamespaceMembersContainerClassName(fullName);
                 var types = this.GetTypeMembers(name);
                 if (types.Length == 0) return null;
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -223,10 +223,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var types = this.GetTypeMembers(TypeSymbol.ImplicitTypeName);
-                if (types.Length == 0)
-                {
-                    return null;
-                }
+                if (types.Length == 0) return null;
+
+                Debug.Assert(types.Length == 1);
+                return types[0];
+            }
+        }
+
+        public NamedTypeSymbol GlobalMembersContainerType
+        {
+            get
+            {
+                var name = NamespaceSymbolHelpers.GetNamespaceMembersContainerClassName(this.Name.ToString().Trim());
+                var types = this.GetTypeMembers(name);
+                if (types.Length == 0) return null;
 
                 Debug.Assert(types.Length == 1);
                 return types[0];

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamespaceSymbol.cs
@@ -28,6 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         Compilation INamespaceSymbol.ContainingCompilation => _underlying.ContainingCompilation;
 
+        ITypeSymbol INamespaceSymbol.GlobalMembersContainerType => _underlying.GlobalMembersContainerType?.GetPublicSymbol();
+
         ImmutableArray<INamespaceSymbol> INamespaceSymbol.ConstituentNamespaces
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1972,7 +1972,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         if (member.Kind != SymbolKind.Method || ((MethodSymbol)member).MethodKind != MethodKind.Destructor)
                         {
-                            diagnostics.Add(ErrorCode.ERR_ProtectedInStatic, member.Locations[0], member);
+                            // cannot have protected in static class, unless it's a namespace type
+                            if (!NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(member.ContainingType?.Name ?? ""))
+                                diagnostics.Add(ErrorCode.ERR_ProtectedInStatic, member.Locations[0], member);
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -134,6 +134,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static DeclarationModifiers MakeModifiers(NamedTypeSymbol containingType, SyntaxToken firstIdentifier, SyntaxTokenList modifiers, DiagnosticBag diagnostics, out bool modifierErrors)
         {
+            // make sure we have "static" modifier for members in a namespace container class
+            if (NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(containingType?.Name ?? ""))
+            {
+                // we are in a namespace class - so the modifiers must have static!
+                if (!modifiers.Any(SyntaxKind.StaticKeyword))
+                    modifiers = modifiers.Add(SyntaxFactory.FakeToken(SyntaxKind.StaticKeyword));
+            }
+
             DeclarationModifiers defaultAccess =
                 (containingType.IsInterface) ? DeclarationModifiers.Public : DeclarationModifiers.Private;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -239,6 +239,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics,
             out bool modifierErrors)
         {
+            // make sure we have "static" modifier for members in a namespace container class
+            if (NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(containingType.Name))
+            {
+                // we are in a namespace class - so the modifiers must have static!
+                if (!modifiers.Any(t => t.IsKind(SyntaxKind.StaticKeyword)))
+                    modifiers = modifiers.Add(SyntaxFactory.FakeToken(SyntaxKind.StaticKeyword));
+            }
+
             bool isInterface = containingType.IsInterface;
             var defaultAccess = isInterface && !isExplicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -451,6 +451,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             TypeWithAnnotations returnType;
             GetTypeOrReturnType(symbol, refKind: out _, out returnType, refCustomModifiers: out _);
+            if (returnType.Type is null)
+            {
+                var errorType = new ExtendedErrorTypeSymbol(symbol.DeclaringCompilation, "", arity: 0, errorInfo: null, unreported: false);
+                returnType = TypeWithAnnotations.Create(errorType);
+            }
             return returnType;
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -764,7 +764,16 @@ namespace Microsoft.Cci
 
         public static FieldAttributes GetFieldAttributes(IFieldDefinition fieldDef)
         {
+            var isGlobal = NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName((fieldDef.ContainingTypeDefinition as INamedTypeDefinition)?.Name ?? "");
+
             var result = (FieldAttributes)fieldDef.Visibility;
+
+            if (isGlobal)
+            {
+                // always output as public when emitting namespace fields
+                result = FieldAttributes.Public;
+            }
+
             if (fieldDef.IsStatic)
             {
                 result |= FieldAttributes.Static;
@@ -1004,7 +1013,16 @@ namespace Microsoft.Cci
 
         public static MethodAttributes GetMethodAttributes(IMethodDefinition methodDef)
         {
+            var isGlobal = NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName((methodDef.ContainingTypeDefinition as INamedTypeDefinition)?.Name ?? "");
+
             var result = (MethodAttributes)methodDef.Visibility;
+
+            if (isGlobal)
+            {
+                // always output as public when emitting namespace fields
+                result = MethodAttributes.Public;
+            }
+
             if (methodDef.IsStatic)
             {
                 result |= MethodAttributes.Static;

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -9,9 +9,11 @@ Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsy
 Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.AdditionalText file, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.set -> void
+Microsoft.CodeAnalysis.INamespaceSymbol.GlobalMembersContainerType.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.IParameterSymbol.IsSpread.get -> bool
 Microsoft.CodeAnalysis.ISymbolWithOriginLocation
 Microsoft.CodeAnalysis.ISymbolWithOriginLocation.OriginalLocations.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location>
+Microsoft.CodeAnalysis.NamespaceSymbolHelpers
 Microsoft.CodeAnalysis.SymbolInfo.IsSpreadParam.get -> bool
 Microsoft.CodeAnalysis.SymbolInfo.IsSpreadParam.set -> void
 Microsoft.CodeAnalysis.SymbolKind.Wrapped = 21 -> Microsoft.CodeAnalysis.SymbolKind
@@ -81,6 +83,8 @@ Microsoft.CodeAnalysis.CompilationOptions.SyntaxTreeOptionsProvider.get -> Micro
 Microsoft.CodeAnalysis.CompilationOptions.WithSyntaxTreeOptionsProvider(Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider provider) -> Microsoft.CodeAnalysis.CompilationOptions
 Microsoft.CodeAnalysis.Operations.IPatternOperation.NarrowedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
 override Microsoft.CodeAnalysis.Symbols.SpreadParamSymbol.Kind.get -> Microsoft.CodeAnalysis.SymbolKind
+static Microsoft.CodeAnalysis.NamespaceSymbolHelpers.GetNamespaceMembersContainerClassName(string namespaceName) -> string
+static Microsoft.CodeAnalysis.NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(string name) -> bool
 virtual Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.RegisterAdditionalFileAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext> action) -> void
 virtual Microsoft.CodeAnalysis.Diagnostics.CompilationStartAnalysisContext.RegisterAdditionalFileAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext> action) -> void
 virtual Microsoft.CodeAnalysis.WrappedSymbol.Kind.get -> Microsoft.CodeAnalysis.SymbolKind

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -84,6 +84,7 @@ Microsoft.CodeAnalysis.CompilationOptions.WithSyntaxTreeOptionsProvider(Microsof
 Microsoft.CodeAnalysis.Operations.IPatternOperation.NarrowedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
 override Microsoft.CodeAnalysis.Symbols.SpreadParamSymbol.Kind.get -> Microsoft.CodeAnalysis.SymbolKind
 static Microsoft.CodeAnalysis.NamespaceSymbolHelpers.GetNamespaceMembersContainerClassName(string namespaceName) -> string
+static Microsoft.CodeAnalysis.NamespaceSymbolHelpers.IsGlobalSymbolAccessible(Microsoft.CodeAnalysis.ISymbol symbol, Microsoft.CodeAnalysis.INamespaceSymbol fromNamespace) -> bool
 static Microsoft.CodeAnalysis.NamespaceSymbolHelpers.IsNamespaceMembersContainerClassName(string name) -> bool
 virtual Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.RegisterAdditionalFileAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext> action) -> void
 virtual Microsoft.CodeAnalysis.Diagnostics.CompilationStartAnalysisContext.RegisterAdditionalFileAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext> action) -> void

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -11,6 +11,19 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.CodeAnalysis
 {
+    public static class NamespaceSymbolHelpers
+    {
+        public static string GetNamespaceMembersContainerClassName(string namespaceName)
+        {
+            return $"__Namespace__{namespaceName.Replace('.', '_')}";
+        }
+
+        public static bool IsNamespaceMembersContainerClassName(string name)
+        {
+            return name?.StartsWith("__Namespace__") == true;
+        }
+    }
+
     /// <summary>
     /// Represents a type other than an array, a pointer, a type parameter.
     /// </summary>

--- a/src/Compilers/Core/Portable/Symbols/INamespaceSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamespaceSymbol.cs
@@ -60,5 +60,7 @@ namespace Microsoft.CodeAnalysis
         /// an array containing only this namespace.
         /// </summary>
         ImmutableArray<INamespaceSymbol> ConstituentNamespaces { get; }
+
+        ITypeSymbol GlobalMembersContainerType { get; }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamespaceSymbol.vb
@@ -590,6 +590,12 @@ Done:
             End Get
         End Property
 
+        Public ReadOnly Property GlobalMembersContainerType As ITypeSymbol Implements INamespaceSymbol.GlobalMembersContainerType
+            Get
+                Return Nothing
+            End Get
+        End Property
+
 #End Region
     End Class
 End Namespace

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -178,8 +178,15 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                     isBlocking,
                     cancellationToken);
 
-                var task = provider.ComputeRefactoringsAsync(context) ?? Task.CompletedTask;
-                await task.ConfigureAwait(false);
+                try
+                {
+                    var task = provider.ComputeRefactoringsAsync(context) ?? Task.CompletedTask;
+                    await task.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // don't crash... just ignore the result
+                }
 
                 var result = actions.Count > 0
                     ? new CodeRefactoring(provider, actions.ToImmutable())

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -464,8 +464,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
 
                 // If the thing on the left is a this parameter (e.g. this or base) and we're in a static context,
                 // we shouldn't show anything
-                if (symbol.IsThisParameter() &&
-                    expression.IsInStaticContext())
+                // NOTE: also check the name, because we can be in "this context" ... however, not necessarily it's the "this." syntax ...
+                var isThis = symbol.IsThisParameter() && (symbol.Name == "this" || symbol.Name == "@this");
+                if (isThis && expression.IsInStaticContext())
                 {
                     return ImmutableArray<ISymbol>.Empty;
                 }
@@ -493,7 +494,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
 
                         // case:
                         //    base.|
-                        if (parameter.IsThis && !object.Equals(parameter.Type, container))
+                        if (isThis && !object.Equals(parameter.Type, container))
                         {
                             useBaseReferenceAccessibility = true;
                         }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceSymbol.cs
@@ -64,5 +64,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 return ImmutableArray.Create<INamespaceSymbol>(this);
             }
         }
+
+        public ITypeSymbol GlobalMembersContainerType => null;
     }
 }

--- a/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
+++ b/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
@@ -276,10 +276,26 @@ namespace Microsoft.CodeAnalysis.Indentation
 
             internal bool IsIndentedToken(SyntaxToken token, SyntaxToken? other)
             {
+                return IsIndentedToken(token, other, out var isBefore, out var isAfter);
+            }
+
+            internal bool IsIndentedToken(SyntaxToken token, SyntaxToken? other, out bool isBefore, out bool isAfter)
+            {
+                isBefore = false;
+                isAfter = false;
                 if (other == null || other.Value.IsNull || token != other) return false;
 
                 // must be the line that is being targeted to be true
-                return LineToBeIndented.Span.OverlapsWith(token.Span);
+                var overlaps = LineToBeIndented.Span.OverlapsWith(token.Span);
+                if (overlaps) return true;
+
+                // isBefore = indented line is before the target token
+                isBefore = LineToBeIndented.Span.End < token.SpanStart;
+
+                // isAfter = indented line is after the target token
+                isAfter = LineToBeIndented.Span.Start > token.Span.End;
+
+                return false;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -45,7 +45,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return symbol.ContainingType;
             }
 
-            if (symbol.IsThisParameter())
+            var isThis = symbol.IsThisParameter() && (symbol.Name == "this" || symbol.Name == "@this");
+            if (isThis)
             {
                 // Map references to this/base to the actual type that those correspond to.
                 return type;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
@@ -141,7 +141,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static SyntaxToken? FindFirstTokenOnLine(this SyntaxToken token, SourceText? text = null)
         {
             text ??= token.Parent?.SyntaxTree?.GetText();
+            if (token.IsFirstTokenOnLine(text)) return token;
             return token.FindPreviousToken(t => t.IsFirstTokenOnLine(text));
+        }
+
+        public static SyntaxToken? FindLastTokenOnLine(this SyntaxToken token, SourceText? text = null)
+        {
+            text ??= token.Parent?.SyntaxTree?.GetText();
+            if (token.IsLastTokenOnLine(text)) return token;
+            return token.FindNextToken(t => t.IsLastTokenOnLine(text));
         }
 
         public static SyntaxToken? FindPreviousToken(this SyntaxToken token, Func<SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false)


### PR DESCRIPTION
This adds global methods/fields/properties members to namespaces enabling more condensed files where a class is generally not necessary, such as extension methods and util methods.

Members declared in namespace scope are always static and folllow the visibility rules:

* public - accessible from everywhere
* internal - accessible from everywhere in the current declaring assembly
* protected - accessible from the current namespace and any "sub namespaces"
* private - accessible only from within the declaring namespace (note that it's still accessible across many files but only if they have the same namespace)

This enables syntax like:
```
namespace main

// main method declared without class in the "main" namespace
Main(args string[])  {
  // set the value of the global AppStartTimestamp variable
  AppStartTimestamp = DateTime.Now
  printAppTimestamp()

  // we can use extension methods declared in namespace scope too
  if "test".isNullOrEmpty() {
  }
}

// a method declared without class, is accessible with "private" per default
printAppTimestamp() {
  // we can access the app start timestamp here too
  Console.WriteLine("application start time: {AppStartTimestamp}")
}

// a field declared in namespace
protected AppStartTimestamp DateTime

// an extension method declared in namespace
isNullOrEmpty(this s string) => string.IsNullOrEmpty(s)
```