### PR TITLE
Updates parsing of member fields converting to properties when upper …

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1587,8 +1587,7 @@ tryAgain:
                                         case SyntaxKind.ClassKeyword:
                                             {
                                                 // for classes we convert field like declarations into properties only if the name starts with "upper case"
-                                                if (TryGetSimpleFieldDeclarationWithVariable(member, out var fieldDecl, out var varDecl) &&
-                                                    varDecl.Identifier?.Text != null && char.IsUpper(varDecl.Identifier.Text[0]))
+                                                if (TryGetSimpleFieldDeclarationWithVariable(member, out var fieldDecl, out var varDecl) && CanConvertFieldToClassProperty(fieldDecl, varDecl))
                                                 {
                                                     member = ConvertFieldToProperty(fieldDecl, varDecl);
                                                 }
@@ -1726,6 +1725,20 @@ tryAgain:
                     _pool.Free(constraints);
                 }
             }
+        }
+
+        private bool CanConvertFieldToClassProperty(FieldDeclarationSyntax fieldDecl, VariableDeclaratorSyntax varDecl)
+        {
+            // cannot convert const to property
+            if (fieldDecl.Modifiers.Any((int)SyntaxKind.ConstKeyword)) return false;
+
+            if (string.IsNullOrEmpty(varDecl.Identifier?.Text)) return false;
+
+            var ch = varDecl.Identifier.Text[0];
+
+            if (!char.IsLetter(ch) || !char.IsUpper(ch)) return false;
+
+            return true;
         }
 
         private bool TryGetSimpleFieldDeclarationWithVariable(MemberDeclarationSyntax member, out FieldDeclarationSyntax fieldDecl, out VariableDeclaratorSyntax varDecl)


### PR DESCRIPTION
Adds naming convention based parsing of fields - automatically converting them to properties if name starts with an upper case and not explicitly defined as "const".

The reasoning for this is that:
  * enforce not to expose "fields" in normal classes ... structs can still expose fields for "performance" reasons...
  * makes defining "standard properties" with a getter + setter much easier ... it's as if defining a field
  * makes syntax "look nicer" without all those "get / set"

This enables syntax like:
```
class Testing {
  firstName string //field... since name starts with lowercase
  lastName string //field... since name starts with lowercase
  _age int //field... since name starts with non alphabetic literal
  
  public FullName //property... since name starts with uppercase
}
```