### PR TITLE
Feature/make async method from await refactoring

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
@@ -232,6 +232,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
         }
 
+        public static SyntaxToken WithoutLeadingTrivia(this SyntaxToken token)
+        {
+            return token.WithLeadingTrivia((IEnumerable<SyntaxTrivia>?)null);
+        }
+
+        public static SyntaxTriviaList GetLeadingTrivia(this SyntaxToken token)
+        {
+            return token.LeadingTrivia;
+        }
+
         public static bool IsRegularStringLiteral(this SyntaxToken token)
             => token.Kind() == SyntaxKind.StringLiteralToken && !token.IsVerbatimStringLiteral();
 


### PR DESCRIPTION
Updates the code fix provider for "Make method async" to not add explicit return type when adding the "async" modifier.

The following code fix:
```
myAsyncMethod() {
  await doSomeAsyncWork() // triggering the code fix "Make method async" here...
}
```
Will generate:
```
async myAsyncMethod() { //async modifier was added
  await doSomeAsyncWork()
}
```