### PR TITLE
Feature/lambda implicit returns

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -1358,7 +1358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return lambdaBodyBinder.BindEmbeddedBlock((BlockSyntax)this.Body, diagnostics);
+                return lambdaBodyBinder.BindEmbeddedBlockForLambda((BlockSyntax)this.Body, diagnostics);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1613,14 +1613,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node != null);
 
 #if DEBUG
-            for (CSharpSyntaxNode current = node; current != this.Root; current = current.ParentOrStructuredTriviaParent)
+            var isFakeNode = (node?.Width ?? 0) == 0;
+            for (CSharpSyntaxNode current = node; current != this.Root && current != null; current = current.ParentOrStructuredTriviaParent)
             {
                 // make sure we never go out of Root
-                Debug.Assert(current != null, "How did we get outside the root?");
+                Debug.Assert(current != null || isFakeNode, "How did we get outside the root?");
             }
 #endif
 
-            for (CSharpSyntaxNode current = node; current != this.Root; current = current.ParentOrStructuredTriviaParent)
+            for (CSharpSyntaxNode current = node; current != this.Root && current != null; current = current.ParentOrStructuredTriviaParent)
             {
                 if (current is StatementSyntax)
                 {

--- a/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
@@ -21,5 +22,15 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public static ReturnStatementSyntax ReturnStatement(SyntaxToken returnKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
             => ReturnStatement(attributeLists: default, returnKeyword, expression, semicolonToken);
+
+        internal static ReturnStatementSyntax ReturnStatement(SyntaxToken returnKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken, SyntaxNode parent, int position)
+            => ReturnStatement(attributeLists: default, returnKeyword, expression, semicolonToken, parent, position);
+
+        internal static ReturnStatementSyntax ReturnStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken, SyntaxNode parent, int position)
+        {
+            if (returnKeyword.Kind() != SyntaxKind.ReturnKeyword) throw new System.ArgumentException(nameof(returnKeyword));
+            if (semicolonToken.Kind() != SyntaxKind.SemicolonToken) throw new System.ArgumentException(nameof(semicolonToken));
+            return (ReturnStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.ReturnStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)returnKeyword.Node!, expression == null ? null : (Syntax.InternalSyntax.ExpressionSyntax)expression.Green, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed(parent, position);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -38,10 +38,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             public static void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
             {
-                var declDiagnostics = context.SemanticModel.GetDeclarationDiagnostics(cancellationToken: context.CancellationToken);
-                ReportDiagnostics(declDiagnostics, context.ReportDiagnostic, IsSourceLocation, s_declaration);
-
                 var bodyDiagnostics = context.SemanticModel.GetMethodBodyDiagnostics(cancellationToken: context.CancellationToken);
+                var declDiagnostics = context.SemanticModel.GetDeclarationDiagnostics(cancellationToken: context.CancellationToken);
+
+                // remove the body diagnostics from the declaration diagnostics so we don't get duplicates
+                declDiagnostics = declDiagnostics.RemoveRange(bodyDiagnostics);
+
+                // now we can safely report the diagnostics for declaration and method bodies
+                ReportDiagnostics(declDiagnostics, context.ReportDiagnostic, IsSourceLocation, s_declaration);
                 ReportDiagnostics(bodyDiagnostics, context.ReportDiagnostic, IsSourceLocation);
             }
 


### PR DESCRIPTION
Enables passing lambdas without return statements as arguments of lambda type with expected return type.
* no return statement becomes a "return default"
* single expression statement becomes a "return [expr]"

Enables syntax like:
```
// method declaration
testMethod(callback fn()string) {
  strResult := callback?.Invoke()
}

// calling method without any return => becomes a "return default"
testMethod({ })

// calling method with a single expression statement => becomes a "return [expr]"
testMethod({ "testing" })

```