### PR TITLE
Feature/backtick string interpolation

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -784,14 +784,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                     break;
 
+                case '`':
+                    this.ScanInterpolatedStringLiteral(isVerbatim: true, '`', ref info);
+                    break;
                 case '$':
-                    if (TextWindow.PeekChar(1) == '"')
+                    if (TextWindow.PeekChar(1) == '"' || TextWindow.PeekChar(1) == '`')
                     {
                         this.ScanInterpolatedStringLiteral(isVerbatim: false, ref info);
                         CheckFeatureAvailability(MessageID.IDS_FeatureInterpolatedStrings);
                         break;
                     }
-                    else if (TextWindow.PeekChar(1) == '@' && TextWindow.PeekChar(2) == '"')
+                    else if (TextWindow.PeekChar(1) == '@' && (TextWindow.PeekChar(2) == '"' || TextWindow.PeekChar(2) == '`'))
                     {
                         this.ScanInterpolatedStringLiteral(isVerbatim: true, ref info);
                         CheckFeatureAvailability(MessageID.IDS_FeatureInterpolatedStrings);


### PR DESCRIPTION
Adds interpolated strings with backtick `this is an interpolated string` which are:
* multiline string similar to how @$"" works
* allows "simple" expressions starting with a dollar - ex: "teting variable $myExpr" 

Enables syntax like:
```
arg := "another string"
str := `
  line 1: testing some text
  line 2: testing simple variable $arg // the arg is a variable
  line 3: testing member access $arg.Substring(3) // this is ok, a variable with member access
  line 4: testing complex expr $arg+4*3 // this is ok, but will only treat the $arg as variable and the remainder becomes text
  line 5: testing nullable expr $arg?.Substring(1) // this is ok, nullable access is also allowed!
`
```