### PR TITLE
Feature/consuming rsharp libraries

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6033,7 +6033,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var defaultImplType = DefaultInterfaceImplTypeGenerator.GetOrGenerate(Compilation, type);
                 if (!(defaultImplType is null))
                 {
-                    allInstanceConstructors = ImmutableArray.Create<MethodSymbol>(defaultImplType.SynthesizedInterfaceConstructor);
+                    allInstanceConstructors = ImmutableArray.Create<MethodSymbol>(defaultImplType.InterfaceConstructor);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (argIsLambda && !hasAnyLambdaArgWithThisScope && namedParamPos != -1)
                     {
                         var param = parameters[namedParamPos];
-                        if (param?.Type?.IsDelegateType() == true && param?.Type?.AnnotationTypeKind == TypeAnnotationKind.ThisParamType)
+                        if (param.IsDelegateParamWithThisScope())
                             hasAnyLambdaArgWithThisScope = true;
                     }
 
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // check if the parameter is of a lambda type that has first argument with "this" scope
                         if (argIsLambda && !hasAnyLambdaArgWithThisScope)
                         {
-                            if (param?.Type?.IsDelegateType() == true && param?.Type?.AnnotationTypeKind == TypeAnnotationKind.ThisParamType)
+                            if (param.IsDelegateParamWithThisScope())
                                 hasAnyLambdaArgWithThisScope = true;
                         }
 
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (argIsLambda && !hasAnyLambdaArgWithThisScope && parameterCount > parameterPosition)
                     {
                         var param = parameters[parameterPosition];
-                        if (param?.Type?.IsDelegateType() == true && param?.Type?.AnnotationTypeKind == TypeAnnotationKind.ThisParamType)
+                        if (param.IsDelegateParamWithThisScope())
                             hasAnyLambdaArgWithThisScope = true;
                     }
 
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (argIsLambda && !hasAnyLambdaArgWithThisScope && parameterCount > parameterPosition)
                     {
                         var param = parameters[parameterPosition];
-                        if (param?.Type?.IsDelegateType() == true && param?.Type?.AnnotationTypeKind == TypeAnnotationKind.ThisParamType)
+                        if (param.IsDelegateParamWithThisScope())
                             hasAnyLambdaArgWithThisScope = true;
                     }
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -164,6 +164,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var embeddedTypes = moduleBeingBuiltOpt.GetEmbeddedTypes(diagnostics);
                 methodCompiler.CompileSynthesizedMethods(embeddedTypes, diagnostics);
 
+                RSharpBuiltInSystemTypes.GenerateTypes(compilation);
+
                 // Compile the generated types if any
                 compilation.GeneratedTypesManager.CompileGeneratedTypes(methodCompiler, moduleBeingBuiltOpt, diagnostics);
                 methodCompiler.WaitForWorkers();
@@ -1868,6 +1870,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (baseType.SpecialType == SpecialType.System_Object)
                 {
+                    return GenerateBaseParameterlessConstructorInitializer(constructor, diagnostics);
+                }
+                else if (constructor is SynthesizedInstanceConstructor && baseType.ToString().Equals("System.Attribute"))
+                {
+                    // synthesized attribute should just call the standard base type
                     return GenerateBaseParameterlessConstructorInitializer(constructor, diagnostics);
                 }
                 else if (baseType.IsErrorType() || baseType.IsStatic)

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -79,7 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return previous;
             }
 
-            return newConstructedFrom.ConstructIfGeneric(newTypeArguments.ToImmutableAndFree()).WithTupleDataFrom(previous);
+            var newConstructedType = newConstructedFrom.ConstructIfGeneric(newTypeArguments.ToImmutableAndFree()).WithTupleDataFrom(previous);
+            return (NamedTypeSymbol)newConstructedType.WithAnnotationTypeFromOther(previous);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ConstructedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstructedMethodSymbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -20,6 +21,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                    constructedFrom: constructedFrom)
         {
             _typeArgumentsWithAnnotations = typeArgumentsWithAnnotations;
+
+            // decorate with the annotation types
+            /*var originalTypeParams = constructedFrom.TypeParameters;
+            if (originalTypeParams.Length > 0 && originalTypeParams.Length == typeArgumentsWithAnnotations.Length)
+            {
+                var newTypeArgumentsWithAnnotations = ArrayBuilder<TypeWithAnnotations>.GetInstance();
+
+                for (var i = 0; i < _typeArgumentsWithAnnotations.Length; ++i)
+                {
+                    var origTypeParam = originalTypeParams[i];
+                    var newTypeArgument = _typeArgumentsWithAnnotations[i];
+
+                    if (origTypeParam.AnnotationTypeKind != null && origTypeParam.AnnotationTypeKind != null)
+                        newTypeArgument = newTypeArgument.WithAnnotationType(origTypeParam.AnnotationType, origTypeParam.AnnotationTypeKind.Value);
+
+                    newTypeArgumentsWithAnnotations.Add(newTypeArgument);
+                }
+
+                _typeArgumentsWithAnnotations = newTypeArgumentsWithAnnotations.ToImmutableAndFree();
+            }*/
         }
 
         public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/GeneratedTypesManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/GeneratedTypesManager.cs
@@ -48,6 +48,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _generatedTypesByKey.Values.ToImmutableArray<NamedTypeSymbol>();
         }
 
+        internal GeneratedTypeSymbol GetRSharpAttributeType(string attributeName)
+        {
+            _generatedTypesByKey.TryGetValue(attributeName, out var generatedType);
+            return generatedType;
+        }
+
+        internal GeneratedTypeBuilder GetRSharpAttributeTypeBuilder(string attributeName, DiagnosticBag diagnostics)
+        {
+            // prepare the type descriptor
+            var td = new GeneratedTypeDescriptor();
+            td.Name = attributeName;
+            td.TypeKind = TypeKind.Class;
+
+            // return a new builder
+            return new GeneratedTypeBuilder(this, td, GeneratedTypeKind.RSharpParamAttribute, diagnostics);
+        }
+
         internal GeneratedDefaultInterfaceTypeSymbol GetDefaultInterfaceType(TypeSymbol interfaceType)
         {
             var name = $"__DefaultImpl_{interfaceType.Name}";

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/DefaultInterfaceImplTypeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/DefaultInterfaceImplTypeGenerator.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var type = tb.ConstructType() as GeneratedDefaultInterfaceTypeSymbol;
                 if (!(type is null))
                 {
-                    type.SynthesizedInterfaceConstructor ??= new SynthesizedInstanceConstructor(interfaceType);
+                    type.InterfaceConstructor ??= new SynthesizedInstanceConstructor(interfaceType);
                     type.InterfaceType ??= interfaceType;
                 }
                 return type;

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/RSharpParamAttributeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/Generators/RSharpParamAttributeGenerator.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.Cci;
+using static Microsoft.CodeAnalysis.CSharp.Symbols.GeneratedTypesManager;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal static class RSharpSystemAttributeGenerator
+    {
+        internal static GeneratedTypeSymbol GetOrGenerate(CSharpCompilation compilation, string attributeName)
+        {
+            var attrType = compilation.GeneratedTypesManager.GetRSharpAttributeType(attributeName);
+            if (attrType is null)
+                attrType = Generate(compilation, attributeName);
+            return attrType;
+        }
+
+        private static GeneratedTypeSymbol Generate(CSharpCompilation compilation, string attributeName)
+        {
+            var diagnostics = DiagnosticBag.GetInstance();
+
+            try
+            {
+                var tb = compilation.GeneratedTypesManager.GetRSharpAttributeTypeBuilder(attributeName, diagnostics);
+
+                // extends the attribute base type
+                tb.WithBaseType(compilation.GetWellKnownType(WellKnownType.System_Attribute));
+
+                // add a default constructor
+                tb.WithDefaultConstructor();
+
+                var type = tb.ConstructType();
+                return type;
+            }
+            finally
+            {
+                diagnostics.Free();
+            }
+        }
+    }
+
+    internal static class RSharpParamLambdaWithThisScopeAttributeGenerator
+    {
+        public const string ATTRIBUTE_TYPE_NAME = "RSharpParamLambdaWithThisScopeAttribute";
+
+        internal static GeneratedTypeSymbol GetOrGenerate(CSharpCompilation compilation)
+            => RSharpSystemAttributeGenerator.GetOrGenerate(compilation, ATTRIBUTE_TYPE_NAME);
+    }
+
+    internal static class RSharpParamSpreadAttributeGenerator
+    {
+        public const string ATTRIBUTE_TYPE_NAME = "RSharpParamSpreadAttribute";
+
+        internal static GeneratedTypeSymbol GetOrGenerate(CSharpCompilation compilation)
+            => RSharpSystemAttributeGenerator.GetOrGenerate(compilation, ATTRIBUTE_TYPE_NAME);
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Type.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.Builder.Type.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal enum GeneratedTypeKind
     {
+        RSharpParamAttribute,
         DefaultInterface
     }
 
@@ -180,9 +181,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public GeneratedTypeBuilder WithDefaultConstructor()
             {
                 return WithConstructor(new SymbolTypeMemberBuilder((t, td, memberIndex, diagnostics) => {
+                    SynthesizedInstanceConstructor constructor = null;
                     if (td.TypeKind == TypeKind.Submission)
-                        return new SynthesizedSubmissionConstructor(t, diagnostics);
-                    return new SynthesizedInstanceConstructor(t);
+                        constructor = new SynthesizedSubmissionConstructor(t, diagnostics);
+                    else
+                        constructor = new SynthesizedInstanceConstructor(t);
+                    t.DefaultConstructor = constructor;
+                    return constructor;
                 }));
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/PublicSymbols/GeneratedType.TypeSymbol.cs
@@ -24,8 +24,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
             }
 
-            public SynthesizedInstanceConstructor SynthesizedInterfaceConstructor { get; set; }
             public NamedTypeSymbol InterfaceType { get; set; }
+
+            public SynthesizedInstanceConstructor InterfaceConstructor { get; set; }
         }
 
         internal class GeneratedTypeSymbol : NamedTypeSymbol
@@ -63,6 +64,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 _typeMembers = typeMembersBuilder.ToImmutableAndFree();
             }
+
+            public SynthesizedInstanceConstructor DefaultConstructor { get; set; }
 
             #region Implementation
 

--- a/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/RSharpBuiltInSystemTypes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/GeneratedTypes/RSharpBuiltInSystemTypes.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal static class RSharpBuiltInSystemTypes
+    {
+        internal static void GenerateTypes(CSharpCompilation compilation)
+        {
+            // generate the param decoration attributes
+            RSharpParamLambdaWithThisScopeAttributeGenerator.GetOrGenerate(compilation);
+            RSharpParamSpreadAttributeGenerator.GetOrGenerate(compilation);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -284,6 +284,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             Debug.Assert(refKind == this.RefKind);
             Debug.Assert(hasNameInMetadata == this.HasNameInMetadata);
+
+            AnalyzeRSharpAttributes();
+        }
+
+        private void AnalyzeRSharpAttributes()
+        {
+            var attributes = GetAttributes();
+            if (attributes == null) return;
+
+            foreach (var attr in attributes)
+            {
+                if (RSharpParamSpreadAttributeGenerator.ATTRIBUTE_TYPE_NAME == attr.AttributeClass?.Name)
+                {
+                    this.IsSpread = true;
+                    continue;
+                }
+
+                if (RSharpParamLambdaWithThisScopeAttributeGenerator.ATTRIBUTE_TYPE_NAME == attr.AttributeClass?.Name)
+                {
+                    this.IsLambdaWithThisScope = true;
+                    continue;
+                }
+            }
         }
 
         private bool HasNameInMetadata

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -271,6 +271,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 typeWithAnnotations = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeWithAnnotations, handle, moduleSymbol);
             }
 
+            AnalyzeRSharpAttributes();
+
+            // this scoped lambda should have a delegate type, for which we need to extract the first parameter type
+            if (IsLambdaWithThisScope)
+            {
+                var type = typeWithAnnotations.Type;
+                if (!(type is null))
+                {
+                    if (type.IsDelegateType())
+                    {
+                        var delegateParams = type.DelegateParameters();
+                        if (delegateParams.Length > 0)
+                        {
+                            var annotationType = delegateParams[0];
+                            typeWithAnnotations = typeWithAnnotations.WithAnnotationType(annotationType.Type, TypeAnnotationKind.ThisParamType);
+                        }
+                    }
+                }
+            }
+
             _typeWithAnnotations = typeWithAnnotations;
 
             bool hasNameInMetadata = !string.IsNullOrEmpty(_name);
@@ -284,8 +304,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             Debug.Assert(refKind == this.RefKind);
             Debug.Assert(hasNameInMetadata == this.HasNameInMetadata);
-
-            AnalyzeRSharpAttributes();
         }
 
         private void AnalyzeRSharpAttributes()

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -394,6 +394,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public virtual bool IsLambdaWithThisScope { get; set; }
+
         /// <summary>
         /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
         /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                         SyntaxToken paramsKeyword, SyntaxToken thisKeyword, bool addRefReadOnlyModifier,
                                         DiagnosticBag declarationDiagnostics) =>
                 {
+                    // check if we have any spread params
                     var isSpread = syntax.Spread.Node != null;
                     if (isSpread && !SpreadParamHelpers.IsValidSpreadArgType(parameterType.Type))
                     {
@@ -48,8 +49,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_DefaultConstructorRequiredForSpreadParam, syntax.Location, parameterType.Type.Name);
                     }
 
-                    var isThis = syntax?.Modifiers.Any(SyntaxKind.ThisKeyword) == true;
+                    // check if we have a "this scoped lambda"
+                    var isThisLambdaScope = parameterType.AnnotationTypeKind == TypeAnnotationKind.ThisParamType;
 
+                    var isThis = syntax?.Modifiers.Any(SyntaxKind.ThisKeyword) == true;
                     var p = SourceParameterSymbol.Create(
                         context,
                         owner,
@@ -65,6 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     p.IsSpread = isSpread;
                     p.IsThis = isThis;
+                    p.IsLambdaWithThisScope = isThisLambdaScope;
 
                     return p;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
@@ -37,5 +37,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 this.Diagnostics = diagnostics;
             }
         }
+
+        internal TypeSymbol WithAnnotationTypeFromOther(TypeSymbol type)
+        {
+            if (type is null) return this;
+
+            if (AnnotationType is null && AnnotationTypeKind is null)
+            {
+                AnnotationType = type.AnnotationType;
+                AnnotationTypeKind = type.AnnotationTypeKind;
+
+                // this param type needs to be replaced with a concrete type if it's a type parameter - it may be that this type is a concrete type...
+                if (AnnotationTypeKind == TypeAnnotationKind.ThisParamType && AnnotationType?.TypeKind == TypeKind.TypeParameter)
+                {
+                    var delegateParams = this.DelegateParameters();
+                    if (delegateParams.Length > 0)
+                    {
+                        AnnotationType = delegateParams[0]?.Type;
+                    }
+                }
+            }
+
+            return this;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -436,6 +436,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type.TypeKind == TypeKind.Delegate;
         }
 
+        public static bool IsDelegateParamWithThisScope(this Symbol symbol)
+        {
+            var paramSymbol = symbol as ParameterSymbol;
+            if (paramSymbol == null) return false;
+
+            if (paramSymbol.IsLambdaWithThisScope) return true;
+
+            var type = symbol.GetTypeOrReturnType();
+            if (type.TypeKind != TypeKind.Delegate) return false;
+
+            if (type.AnnotationTypeKind == TypeAnnotationKind.ThisParamType)
+                return true;
+
+            return false;
+        }
+
+        public static bool IsSpreadParam(this Symbol symbol)
+        {
+            var paramSymbol = symbol as ParameterSymbol;
+            if (paramSymbol == null) return false;
+
+            return paramSymbol.IsSpread;
+        }
+
         public static ImmutableArray<ParameterSymbol> DelegateParameters(this TypeSymbol type)
         {
             var invokeMethod = type.DelegateInvokeMethod();

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -60,6 +60,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             AnnotationTypeKind = annotationTypeKind;
             AnnotationType = annotationType;
+
+            if (AnnotationType is null && annotationTypeKind is null)
+            {
+                AnnotationType = defaultType?.AnnotationType;
+                AnnotationTypeKind = defaultType?.AnnotationTypeKind;
+            }
         }
 
         public TypeWithAnnotations WithAnnotationType(TypeSymbol type, TypeAnnotationKind annotationTypeKind)

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
@@ -59,6 +59,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             set => base.IsThis = value;
         }
 
+        public override bool IsLambdaWithThisScope
+        {
+            get
+            {
+                if (_underlyingParameter.IsLambdaWithThisScope) return true;
+                return base.IsLambdaWithThisScope;
+            }
+            set => base.IsLambdaWithThisScope = value;
+        }
+
         public override TypeWithAnnotations TypeWithAnnotations
         {
             get { return _underlyingParameter.TypeWithAnnotations; }


### PR DESCRIPTION
Adds RSharp metadata attributes to method parameters with information about "Spread parameters" and "Lambda types with 'this' scope".

Auto generates attribute types for each assembly - so that no specific "runtime library" is required.

This allows us to consume method definitions across assemblies - otherwise the "Spread" parameter and "This scope" is lost when compiled into an Assembly.

Allows us to do the following:
```
// TestLib project / assembly

namespace testlib

public class MySpreadArgs {
  Width int?
  Height int?
}
public MyAdvancedMethod<T>(this t T, args ...MySpreadArgs, callback fn(this T)) {
  // ...
} 
```
```
// TestExe project / executable
namespace main

import testlib

class MyType {
  Name string
}

Main(args string[]) {
  o := new MyType()
  // we can consume the method from "TestLib" and expect the spread / lambda logic to work
  o.MyAdvancedMethod(width:10, height:10) {
    // this scope is type type of "o" ... which is MyType ... due to "this scoped lambda"
    name := this.Name
  }
}
```

